### PR TITLE
Add derivation and code generation for 3-body Jastrow

### DIFF
--- a/Wavefunctions/ThreeBodyJastrowPolynomial.ipynb
+++ b/Wavefunctions/ThreeBodyJastrowPolynomial.ipynb
@@ -1,0 +1,1660 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sympy import *\n",
+    "from IPython.display import display\n",
+    "init_printing()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Three-body polynomial Jastrow\n",
+    "\n",
+    "Three body Jastrow factor from \"Jastrow correlation factor for atoms, molecules, and solids\" N.D.Drummond, M.D.Towler, R.J.Needs, PRB 70 235119(2004)\n",
+    "\n",
+    "See the 'gen_three_body.py' script for code generation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAFwAAAAaCAYAAAA67jspAAAABHNCSVQICAgIfAhkiAAAAy1JREFUaIHt2UuIXEUUBuCv89CEFhyJ4BMRFAMxpjsqEsEHQtStiOBGg+jCnS5cuRtETCBEERTRVXARVAwaNAhuBIPiE6MuImYXkeCo8R1lfCSLugU1ZfXt7qH79vQw/6boU131/+fcqlPn1m3Nzs5aQXNY1cP+IubQblDLcsI1OIUH8o5SwK/FPdiFP8ara9niU7yOx3FW2lEK+BP4Fc+NX9eyxk6cj4dSYx7wK7Adr+DPZnQtW3yEr/AgVkdjHvD70cLLhQluEfLSblyHAzhR2a4cvd6J8o6K8yVcIixi/D/g2/EvPigMvrpqN+MQ/sPz2Cc8yXFhEryj4nyvam+NhjVJZxtdHFE+LKOIG3Cz8kMZBybBOyrOj6v2pmhIV/hFQq453kfEwzUCnsWrixTXC/14d+LthjlzP3tp+AV/CWkFtJIXn+vxvnBg3p0NbAuVyw+4QNhiJZyDv/F7j/5hMQjvjJAGf2uQM/ezTsO3OE+VTdKUEquSdYVBHWE3HOwhIOKnmr7FYBDenyfAmftZp2G9pOJLU8pc1W4oDIpb7MOaiS8WTvGNNf8ZFv14ZyrOToOcuZ91GlZV/XOpIeI4vlcOWBTxSY3QLk7iaM1/hkU/3q6wtY80zJn6Wadho1BmH46GNOCn8C7OxeUFEfP4skZoB19YuA33VvPeVzOuDv14Y1U13yBn7mdJQ8S2qn0nGvI6fH/V3p7YzsSmSkBp0oiu5Elm8/9TM64XBuFdCpwlDRG3CYfpgVxcxH58hx2JbTPWChcydegUiK8STu6DfcaWMAhvB59PgPNw9jvXAGfjDryJb6JxTfaneTwtXGBtxWcVeauP0DYuy4TMYAv2WFz10o93rbAaU2fHzZn7WdIQsUOo+PakxtJt4VM4hseGELqlatO8d6NwmDw5xDzDYBPOsPAhj5sz97OkgVAKPipkjENpR77CCW9G9woXOG2D3Yl38LVweke8oVzTjwpd4aXixwY5cz9LGuBSvCAc4AvQmuJPbM/gQtw5TRp6fWJbylgvfJW6C29Nm4ZpDPgjwuer1xS27FLXMM0pZSoxjSt8qrES8IaxEvCGcRp1DOJbZ2G18QAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$\\displaystyle \\left( r_{i}, \\  r_{j}, \\  r_{ij}\\right)$"
+      ],
+      "text/plain": [
+       "(rᵢ, r_j, r_ij)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ri = Symbol('r_i')\n",
+    "rj = Symbol('r_j')\n",
+    "rij = Symbol('r_ij')\n",
+    "(ri, rj, rij)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "C = Symbol('C')  # C is 2 or 3\n",
+    "L = Symbol('L')\n",
+    "gamma = IndexedBase('gamma')\n",
+    "r = IndexedBase('r')\n",
+    "l = Symbol('l',integer=True)\n",
+    "m = Symbol('m',integer=True)\n",
+    "n = Symbol('n',integer=True)\n",
+    "N = Symbol('N',integer=True)\n",
+    "N_ee = Symbol(\"N_ee\",integer=True)\n",
+    "N_en = Symbol(\"N_en\",integer=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$\\displaystyle \\left(- L + r_{i}\\right)^{C} \\left(- L + r_{j}\\right)^{C} \\sum_{\\substack{0 \\leq l \\leq N_{en}\\\\0 \\leq n \\leq N_{en}\\\\0 \\leq m \\leq N_{ee}}} r_{i}^{l} r_{ij}^{n} r_{j}^{m} {\\gamma}_{l,m,n}$"
+      ],
+      "text/plain": [
+       "                        Nₑₑ   Nₑₙ   Nₑₙ                               \n",
+       "                        ___   ___   ___                               \n",
+       "                        ╲     ╲     ╲                                 \n",
+       "         C           C   ╲     ╲     ╲     l     n    m               \n",
+       "(-L + rᵢ) ⋅(-L + r_j) ⋅  ╱     ╱     ╱   rᵢ ⋅r_ij ⋅r_j ⋅gamma[l, m, n]\n",
+       "                        ╱     ╱     ╱                                 \n",
+       "                        ‾‾‾   ‾‾‾   ‾‾‾                               \n",
+       "                       m = 0 n = 0 l = 0                              "
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# General form of the 3-body Jastrow\n",
+    "f = (ri - L)**C * (rj -L)**C * Sum(Sum(Sum(gamma[l,m,n]*ri**l *rj**m*rij**n,(l,0,N_en)),(n,0,N_en)),(m,0,N_ee))\n",
+    "f"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA6wAAAAdCAYAAACuReEJAAAABHNCSVQICAgIfAhkiAAADKlJREFUeJztnXusHkUZh58iFmtRICACEq0KRS7hFKjEEKkQQQ1GRQLhH6knJQo0BgwJGkwhp8YIinJRCIoGDqAG0BqJFwImgmiRi1UEFFAbjogSEKooYqkC/vHupvvt2fl2ZndmZ3e+90lONt395tLfzPvbnd3Z2QUzMzMoiqIoiqIoiqIoSt/YJnYFEmQK+CbwGLAZeAS4Ftg/ZqUSRvVWFEVRFEVRlETRAatfVgIbgOeBE4Gl2T6A02NVKmFUb0VRFEVRFEVJGNOA9RrgSWBxh3XpO4cALwEnG44fBlwJnAWsAtYDjwI/A04CzjakU62rCaU3wCv8VVOJhMaN4ps6zxkK6m/DR/1N8U0q/tYnFsWuQKJU6lo1YF0OfAg4H/h3gIr8BAmawwPkHZINwPeAzwDbVxy/GLgDuMiQflPFPtXaTAi9AU5FL+iGTui4USaTOs8ZAupvw0f9TQlBCv7WN94HLIldiQSp1LVqwPpZ4J/A5QEqsQA4GHgR+HWA/ENzHrAb86ebvgV4K3CZY36q9Xh8630sovc/2ldNiUjIuFEmG5PnDAH1tzRQf1NCMWR/6yPfAc5BbxL6plLX8oB1KXAUcAPwnwCV2BvYAXgYeNZDftPIE8QjPORlw93AQ8ApwMsK+5dl2w0OeanW9fjUeyFwGvAtP1WbWKbpvh8UCR03k8Q0cduyj5g8x5Zp4miq/taeaeLHg/qbH6aJ35Z9ZKj+1ldeBNbR/gbANKprkUpdywPWVciTuesDVeKQbOsy0AjJkUgnuQA4FLgRmUr6EuZVZq8DXo+cVHLy+dYuA0PVul5r8Kf3qcCtHup2HPBf4C7gDYb81mZpP+pQv0mgaR8oUhc32pbhSV23Ks/piqYxYvI31/xSb9uQhPY3bctuSF23WP6Wqq43I4t97hih7FQ1hQpdywPWo4AXgDsDVWB5tv1loPxdOTjbHoAs1vMi8FXkLvVDhjTrs+3RhX0PZNsVhjSvrNinWtdrDf70PgN5f6Nt3Z4AfoxcMHyiIq83ZfvvAb5uKG9SadoHitTFjbZleFLXrcpzuqJpjJj8zTW/1Ns2JKH9TduyG1LXLZa/parrC4imH45QdqqaQoWu2xYOLkamWj5IuBf9+zqIejvwDuwGj/dk2xWlfT8CLkUGS+uROxqHIHc11gC/KPxetbYfqPvQ+yDgtcDvPdRtPfBB4Gm2alzkS8j0vNXIBYWylaZ9IMcmbrQtw5O6blWe0xVNYmScv7nml3rbhiS0v2lbdkPqusXyt5R1/RWyUNolHZebsqZQ0rX4hPV1yJz2xwMVvA1yYn0BuDdQGa7kJ4AzsD+5PANsRqZUFDkO+AJwJvL/uwe5s7Ge+Yseqdb2+ND7cOA+zAHrWrfngd8B+5b2vx94L3AF/blR0Cea9oEcm7jRtuyGlHUzeU4XNImRcf7WJL+U2zYkof1N27I7UtYtpr+lquu9yFPO7SKUnaqmUNK1OGDdOdv+3ZBwDnmKZfv3jVL6pcCrkKkrTZ4qVpV/VXbs1opjszX5Lc7q9OSY316GrFZVZhOwS2nf88DngQOzvHdCnvidi5hDkTqtoZ3eQ9T6POAWw7G2eu+HTJ1oWreqfvAQovGe2b8XIZ/aeQr4lCGfoTGHv37QROdyn6iLG21LM3P4jWlIW7cqzykzRz980uRvNvnBZMbEHPGvJ1z8TdvSzBz+vQ3S1i2Gv+WkqOsTyJPMN1r8dg49F9syomtxSnC+Ip1peeaNzB8IjOOvpX+3naJ6MfNfal4GfAC4GukEReqeLE4hA/YfYn7ytgZ5obnMItqt4FenNbTTe4hafw55IlxFW733wPxd1qb9IH9naD/gMeBsJKhOZvSCYwVwFjKY3h04geqbIONYneWxO/Bb4OPIO0yh0/vsB010LveJurhJvS3blO87psFeN4jXh6GZbjae0xefNPmbTX4QNyZixVQfridc/G0S2rJp+hDeBt35WwzdYvhbzlB0dSn/mWy7B/Xvq0/yudg1/YiuxQHrk9l2Z6p5p0OFqsgHUU1Xrb24Yt800sizwG2O+eXTa+4a85uqO53bIJ3tEcfyitRpDe30HqLWpm8H+tB7MfAnw7Gm/aBoEBuR6ch3svVOWbHs32T719lUtsSJyPz91cDPkU9X3JSV+2jg9D77QROdy32iLm5Sb8s25fuOabDXLWYfBnfdbD2nLz5p8jeb/CBuTMSKqT5cT7j42yS0ZdP0IbwNuvO3rnWL5W85Q9HVpfx/ZduqBT/LTPK52DX9iK7FKcGPA38D9rEotAn5Z1b6Mpc6PwGY6rMn8ji+rMc+yLLzbd4NVa1H2RHReqrimA+9t2B+Kte0HxQN4hJktsLq7LdFbkLuen/Xob5FzkRM7GvIYhynI/3ntI7S+8JV56o+URc3qbdl2/J9Y6tb7D7sqpsPz2lCU580+VtdfhA/JmLHlC9C+9sktOWk+lvXusXyt5yh6OpSfu6/WxqW1ZahnItd04/oWhywvgTcjsxr38uycFv6ugjQFuB+w/FlwHPAH0r735Ztb21Rtmo9yjJkGtODFcd86L0JeHWLulX1gz8iGp+AvNh+OfMXe2rLQuTmQ/mdtVuAwzpI7xNXnav6RF3cpNyWfcRGtyH2YR+e04SmPmnyt7r88jxjxURb+hRTof0t9bbsI134Wwxi+VvOEHR1LT/3X9OrZ6EZwrm4SfoRXcvfYc0fm7/bonAX9kUez28Gvox8D6j8d77nMsexHXIn4n7Md0SmqF558V1Ix7ixZR1U663kS/lXHfeh90aqP+rcph9sQabU7IhM5TqnRf1M7IKsGlleUOUJYLcO0vuiic6mPmGKm9Tbso/Y6DbEPuzL411o45NV/maTH8SNibb0JaZC+9sktGUf6cLfYhDD34oMQVfX8nP/3RiyUmMYwrm4SfoRXbctHVyXJV6JrDbni3yK6mLkJeAqbvZYXh0HAC9n/Duey5j/hHIH4FjgB8CfW9ZBtd5KldbgT++7gFWe6wYyDWMv4JOY38H1QXlax4KKfSHTt6WJzibdTXEzKW3ZN2x1G0of9unxLrTpv1X+ZpPfuDyhu5hoS+yYCu1vk9SWfaMrf+uKWP5WZii62pa/P/Id7HFf/gjNUM7FLulHdC0/Yd2CzH8+FJlW6otrskqN+3tPg3xns7S3OabbkKU7Zcxvpphv/iuROdVfdCyvCtV6K1PIy/FlfOn9U+SzN69pWDfTRcBOyN3sb7esn4mnkDuh5btPu2L+TI/P9FXM4t4Pmuhs6hOmuEm9LUMwS7OYLlKnWx/78Djaes4s3ftklb/Z5JfnGSsm2uK7b8zS3fWEi79NQlv6Zpb23gbh/a1rYvlbmb7r6lr+Qcg7s02ZJf1zcZP0I7qWB6wAFyGrNX3aogKpshh4M6PmvwhZKnodbks4j0O1ljvH+zH/5O1T72eBG4AjHNNV9YOcBcgFwsM0+9atDVuQi5WjS/uPBu7oIH1XlHU29YmcJnEz9LbsIza6DakPh/B4X4yLiaH6W1uGElOT4G8p0oW/dUlf/G0IurqWvwK4MnSlxjCEc3GT9CO6lqcEg7z7eBJwJGKCk2hwB2bb4gIHS4ArsP84sg2qtZy4FzL/RLsEv3qvBS7E7Q5zVT/I2RvYnvrFK7ZndAGNJcjUrU3YLQN+IXAtcDewHrnLvgfwFYu0PtJ3QVlnU5/IaRI3KbRl2/J9Y6tb7D5sq9sS/Hu8L+piYqj+FjumumBS/C12et905W9d6baEfvjbUHS1LX8pMr36Pst6hWAo52KX9PN0rRqwgqxUd7tlBVJkCpk3/Vxh34PATICyJl3rZcBfgKdL+33rPYesnrgUaVsbqvpBTj5dq84gljO6Gt8F2fZq5NtbZNurkA89z5XSX498l28N8qHlB4BjGP3uYtv0sSnrbOoTRVzjJoW2tCm/S2x166IPj0tvq1soj/dBXUzMMUx/6yKmYjMp/tZF+i7pyt+60q0v/jYUXW295SPEX8hsKOdiF7+ep+uCmZmZsf87RQnMpcgdluM6KGshEgDn0q8FEdYCxyMXHf+LkL5vdNknfKNt2QzVbTw2MaH+NgzU39JpS1tUtzDE1nU58hT3ugZp+0psTcGga9U7rIrSBYuQTnk87V5WdyFf0GLXjsqz5RjgYzQP7rbp+0KMPuEbbctmqG7VuMSE+lu/UX9Lpy1dUd3CEFvXzaQ1WIX4moJBV33CqsRiDXAq8H3gdOQj6spko31CUUbRmEgHbUtFUZSG6IBVURRFURRFURRF6SU6JVhRFEVRFEVRFEXpJTpgVRRFURRFURRFUXqJDlgVRVEURVEURVGUXvJ/kL7qS8xmvmQAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$\\displaystyle \\left(- L + r_{i}\\right)^{C} \\left(- L + r_{j}\\right)^{C} \\left(r_{i} {\\gamma}_{1,0,0} + r_{ij} \\left(r_{i} {\\gamma}_{1,0,1} + {\\gamma}_{0,0,1}\\right) + r_{j} \\left(r_{i} {\\gamma}_{1,1,0} + r_{ij} \\left(r_{i} {\\gamma}_{1,1,1} + {\\gamma}_{0,1,1}\\right) + {\\gamma}_{0,1,0}\\right) + {\\gamma}_{0,0,0}\\right)$"
+      ],
+      "text/plain": [
+       "         C           C                                                        \n",
+       "(-L + rᵢ) ⋅(-L + r_j) ⋅(rᵢ⋅gamma[1, 0, 0] + r_ij⋅(rᵢ⋅gamma[1, 0, 1] + gamma[0,\n",
+       "\n",
+       "                                                                              \n",
+       " 0, 1]) + r_j⋅(rᵢ⋅gamma[1, 1, 0] + r_ij⋅(rᵢ⋅gamma[1, 1, 1] + gamma[0, 1, 1]) +\n",
+       "\n",
+       "                                  \n",
+       " gamma[0, 1, 0]) + gamma[0, 0, 0])"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Concrete example for N_en = 1 and N_ee = 1\n",
+    "f1 = f.subs(N_en,1).subs(N_ee,1).doit()\n",
+    "f1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABUIAAAAfCAYAAAAiE7eDAAAABHNCSVQICAgIfAhkiAAAEdBJREFUeJztnX2sJ1V5xz9LFd0uCCpYXIndtrrqQrgXd6UNlC1bQFuNFomENEF6o6kCMWistqFZzS6aYkVki4pWiN5iNfhCqsHW1KJra5eCK60ClZdCuForAZSCxXZZeekfz0zu3LnzPmfOmTO/7ye5GXbmd+Ycvs85z3PmzJlz1uzYsQMhhBBCCCGEEEIIIYSYMgeELsAEmQM+DfwQ2AfcA3wKOCpkoSZMV71V94UQsXIBsBf4KfAAcC1wdNASCSGEEEIIIcR4KB3z0WCQW84GbgIeBc4ENibnAM4PVagJ01XvjcBZwxZNCCEG4yTgcuB44LeBx4DrgGcFLJMQQgghhBBCjIU5YFvRhbKB0KuA+4F1Q5UoQjYDTwJvLLl+PPAJ4J3AG4A9wA+AbwKvx2bwFCGtixlK74OBDwKfc1lYEQS1HeGaOr8zFl4BfBK4FbgF83mHAyfUpHv6wOUSwyO/J1wTi9+LjbWhC+AIxY34UdwQrlHccM9UYsbY+DfgtdhEuBUUDYRuwWbLvQ/42QCF+TrWcE4c4N5DchPwReC9wEEF13cB1wOXlqR/sOCctC5nCL0BLknS7utbQBGUoduOmE3q/M5YORiL52V+D+Ac9EAbO/J7Yghi9Xtj59XAhtCF6IniRvwoboghUNxwzxRixlh5D3AFubHPooHQP8PWHfvoAIVYA7wUeAIbnY2Ni4AjWP3Z9YuBlwEfaXk/aV2Na703YzNJr+tfNBGYIduOmG3K/M6Y2QV8B7ih5PppWHt5yFuJxBDI74mhiNHvjZ0vAO8i3oFExY1poLghhkJxwy2xx4wx8wBwO/D72ZP5gdCNwCnYZ8P/N0AhXggcAtwBPOLgfgvYjMeTHNyrCd/CRHwz8AuZ8/PJ8aYW95LW9bjUG2A79nmI6McC/utClqHbziyxQFhbjpEyv9OGBfzpejGwFTgDeLzg+oHAucBnPJRlyiwgvzcVFpDfyxOb34uBJ4Br6DdIsEAYTRU3+rNA+PaguOGGBcLbcoz0jRsLSNcsLmIGSNcy/gq4EHhqeiI/EPoGbCbhZwcqwObk2HYAayi2YRXlYuA44EvYp4VPUr7r+NXA87HAkpKu6dBmwFFa12sN7vQ+EngN8HlH5Tsd+DlwI/DLJffcmaR/U4tyzgJd60JKXduRLf0wZd2K/I5PmtbhS7AN4k4G7iq51znA7p75pEzZ5kMjvzcNpqxbKL83ZU3/HvPRhwbKv6vfKYsb8jP+6BszoDpuyJZ+mLpuihtuCRkzpqppyvXA07D/T2D1QOgp2IySss/r+rIlOX57oPu35aXJ8Whsk50ngL/E3oDeXpJmT3I8NXPu1uS4tSTNLxack9b1WoM7vc8EHgbucVS++4B/wDoPf1xw/VeT83uBK0vynFW61oWUurYjW/phyroV+R2fNKnDl2Hrfm0Dvldxr7di6zh1zSfLlG0+NPJ702DKuoXye1PW9HFM1z8IlH9Xv1MWN+Rn/NE3ZkB13JAt/TB13RQ33BIyZkxV0yz/Subz+KdkLqzDPjm+jeEWUx7r4NxvAr9Fs0HJvclxa+7c3wEfxgbh9mCj5ZuxEfPtwL9kfi+tmw8Au9AbrDNQtVZq2/LtwXYg+wnLWme5DPu06DyscyGW6VoXoFnbkS39MGXdivyOT+rq8OXYIOhp2AyOI5Lzj7BypvyxwC8Bd3bMJ8+UbT408nvTYMq6hfJ7U9YU7MHrLOAvAuTdxe9UxQ35GX/0iRlQHzdkSz9MXTfFDfeEihlT1jTlO9iLvgOAJ7IzQp+Hre9w70AZH4AF18eTQoyBNAi8leYB5mFsx/Hn586fDnwAeDv2/7cXGzXfw+oBOGndHBd6A/w6yzNJXZXvUWwm1kty518DvAr4OOMZiB4TXesCNGs7sqU/pqpbmd/xRV0dPhfbKf5rWFtI/96R+92JwM2Ud1jUVvwhvzcdpqpbSL83VU3B+qjHYZ/k+aaLX6iKG/Iz/ugTM6A+bsiW/piyboob7gkZM6aqacqtwDOATbDy0/hnJ8f/Lkm4hM26a/r317n0G7EHt9vpNguyKP9PJtd2F1xbrLnfuqRM91f89iPYDl55HgQOy517FHg/cExy72diMxTfjTmILHVaQz+9Y9T6IuCrJdf66n1Ycr1M7z514XZM6yOTf6/FdnD+MfCnJfeKiSXCt7ts3ahrO03uX5QHyJZtbZkyVd2K/E4RS/hvI2tK/nbkfrcJ+9Slaz7ye9Pxe7Kl/F4TQvk9mK6m92GzaH6l5ndLjKPvXRY31L8qZ4lxxQyojhuyZTlLKGa0pUncWEK6NqVpzADF4rak/vAFsPLT+HQ3uaeXJLyb1QNMVfwo9+++n2rvYvXCsfPA72G7QC3lrtXNhJzDBoL/lvLZMtuxRWPzrKXf7nt1WkM/vWPU+s8p3vEY+uv9vOT405LrfepCuo7OJuCHwAWY43ojKzsfW4F3YoO1z8V2eC56KK3ivOQezwX+HXgbtq7PkOnH0O6ydaOu7TS5f1EeEI8tu+bv2pYpTXWDMHU4pa1uTf1OiDbSlPVYB7VrPn38not2cgE2+/9F2MuvG5JzVbP788jvFd8/JRZbxur3+vo837qF8nvgL5b49isPJ8f1VK/tOJa+d1nciKF/Fap/NraYAdVxYxZsGWvMgDDPCH3SN4kbs65rm/ybxgyIOxaHSJ+OBa2HlQOh9yfHZ1PMyS0KVUQ6ONd1F/NdBecWMEMvAt9oeb/0k4AbK35T9BbtAKzC3dMyvyx1WkM/vWPU+qGS8y70XpccHy653rUuwEpncTf2ef4NLL+NyZbhu8n5a6oKW8KZ2Foh5wH/jH0a+5Uk3x8MmH4M7S5bN+raTpP7F+UB8diya/6ubZnSVLdQdTiljW5t/E6INnIR1hl7ec291gHf75FPH7/Xt50AnISth7oXm/F6IXBdkm/ZAG8W+b3y+6fEYssY/V5fnwV+dQvp98BfLDkJv37lf5Jj0UaeWcbS9y6LGzH0r0L1z8YWM6A6bsyCLWOMGRDuGaFr+qZxY9Z1bZN/05gBccfiEOnTsaB1sHIg9F7gAewN6RBsTo5jWVcgDQJl5TkS+E/gxcAdmfMvwjpOfdbelNYrORQLtvOYk8niQu81yfHJjuUrqwuw0lmcgrWp8wry+kry15W3Yw7tiuTf5wO/izX6Czykd0VbrfN1o67t1N2/KI+UWGzZN3/XNNUtdB1uo5sLv9OVJnW4agZ9lv2UzyIc2u+5qKevyP379Vgn5gTg2gbp5feK758lFlvG6Pdc1D+fuoX0e+Avlvj2K6kP3t/g3i7p2vcuixsx9K9C989c0TdmQHXcmAVbxhgzIPwzQtv0sxI3fPqWUDEjJZbnui7p0xnwa2DlGqFPAv+ErfHwggaZt2Gsm/fsB24puT4P/C/wH7nzv5Ecd/fIW1qvZB779OK2gmsu9E7XSX1GyfWudQHgLkzrM7BFhD9K9e70XTgQG9zOr+P0VeB4D+ld0lbrfN2oazt19y/KIyUGW46RJrrFVodd+J2uNKnDD7H8xriKB4nX7xVxMBbjmszaGlNbC+33YrflGKnTbaj6N6RuIf0e+IklRQztV1If7Luud+17l8WNsfev+jKlmAHVcWPqthwjofzb0Mxq3GhD2/xDxYyUGJ7ruqY/JDn+DFYOhMLyVN/829K+vASbgroP+BBwZcHf+xznWcXTsFHuWygfbZ+jeNfEl2OV40s9yyCtl5nHgnfRdRd6p4u+F3Xs+tQFkjT3YG9j7wfe1aOcZRyG7fyYX7z+PuAID+ld0UXrorpR1naa3L8oj5QYbDlGmugWWx125efb0qQOH4o94Mw1uN/drF47qGk+of1eEbuwF3xNdrgdS1sbg9+L3ZZjpE63oerfkLqF8nspPmJJEUP7ldQH392pdN3o0/cuihsx9K/6MrWYAcVxYxZsOUZC+behmdW40Ya2+YeIGVlieK7rmj4dC7oXigdC7wPOblCANqSfaq/DFlot+pt3nGcVRwNPpXoNzXlWz6g8BDgN+DL2uUAfpPUyRVqDO73vxUb+iwYE+pQvJZ1C/ieUr3XqgvyU9DUF54ZM35cuWhdpX9Z2mty/7J4psdhybDTVLYY67NLPt6VpGymbQZ/nRuCoHvmMwe+lXIwtVn8GzZYFSAnd1sbg96Ziy7HRRDeX9W9I3UL6vSy+YkmKD79yFHAn5ev0DkEfv1AUN2LqX/VlKjEDiuPGLNlybPj2b0Mzq3GjK03zDxEz8sTyXNc2fToj9C5YPRC6H1t09Djs82pXXJUUrOrvdzrcdzFJ+42W6W5K0r254jdzrA4AZ2PrNlzSMr8ipPUyc6xeGxTc6r0Xmy2bp2tdyPJM7I3p5zuXrpofYx30/BuO57D6TcgQ6fMs4q/dFdWNsrbT5P5FeWQZuy1ds0g3W+ap021sdbgKF35nkeHaSNUM+jz/iNnm8A75hPZ7WS7B7HIySeelAfJ75ffPM3ZbumaR4f2e6/o3tG4h/V6WoWNJFl9+5Vi6ry23iP++d1HciKF/1ZepxQwojhuzYEvXLBJHX9k3fePGIrOha9v8+8QMiCMWh0q/CZsc9z1YPRAKcCm209KFDQoxVdYBv8bKALAWW3j1GuCbjvKR1vZWchOrA7hrvXfTbcC5qC5kWYN1Fu5geS1S1+zHOi6n5s6fClzvIb0v8lqX1Q3o3naq7BmDLcdIE91iqcND+HnX1M3uy/II8Dlsl+Q2jMHvpVwGnAVsI+m4NCSWtja035uCLcdInW4u69/Quo3F7/mIJSk+/cpW4BMt8vBBlZ8ZIm749DNdmWLMAPdxIwZbjhGf/s0Hsxg3utI2/9AxI4bnuq7pj8XWTn4MVu4an7IP20FxG+YIZ9HJHZMcs4tIbwA+jo2yu0JaW/A+kNXBdgNu9b4a2AmsB37UIl1RXcjyQuAg6hcKP4iVi5VvwAY0HsQ6KHV8EPgU8C1gD/Ymdz3wsQZpXaT3QV7rsroB3dtOlT1jsWXf/F3TVLfQdbiJbhtw7+ddM4fp0JSdmHZtZm648Hsu6unl2GDFaUm69M3vI8lfHfJ707FljH7PRf3zodsGxuH3fMUSn35lI/bJ6M0Ny+aLKj8D7uOGr/5V6P6ZD9rEDHAfN2KxZYwxA8I/IzRNv4HZihu+fMsYYkYsz3Vd0h+LxTegeEYo2EjpTmZzYA7sQfNObLe8lNuAHcCS47xmXet54L+An+TOu9b7TuDrwOkt0xXVhSzpLNM6Z7El+U36u4uT/86+oV3A1rXYUJD+s8DbgO1YZ+dE4JXA9x2mD01e67K6kdKl7VTZMxZbNsnfJ01181GHq9I30W0oP++KupkfRSxhu75ubJHGhd/r204AzsV2dP4attZz+veOhunl96Zjyxj9Xl+fBX50G4vf8xVL6jStS9/Gr/wh49xMps7PLOE2bvjqX/non4WmbcwAt3EjFlvGGDPAT1+3b3qYvbjhy7eMIWbE8lzX1l/PYZslfSE9sWbHjh0lvxXCCx/GRu/bDlB2YRvwfuBlHvLqwk7gdVhDfSxA+rHhs264RrbshnSrJl2z6zCqH3ryHIh1rN7NuBbcl71XE6vfky27Id2GYQy6bsFmEF3dMf2QNPEzihtxEGvMANmyK9JtGELrOuaY0ZXQmma5FJvB+570RNmMUCGGZi3W4F9HvwWB27Abe3N1nKf82vJK4C10b+h904+FEHXDNbJlN6RbNU1mfhSRbpjwHOcl6ofsvUzsfk+27IZ0G4Yx6LqP8T3QtvEzihvjJvaYAbJlV6TbMITWdYwxoy+hNU05GDgB+ED2pGaEilBsB84BrgXOB37uKd/DsQWIX4sCwFgJVTeEGDsxz/wQ1cjvCSGGRn5mOsiWQgjRjF0UbOylgVAxi2zB1tm7KnRBhBCiAWuBo4AvY58qXhG2OEIIIYQQQggxao7Bvga+Mn+haNd4IabOtynfQVcIIcbGH2EzP/6G8Dt0CiGEEEIIIcTYuQO4ueiCBkLFrPJo6AIIIURD3pv8CSGEEEIIIYSop3TMR5slCSGEEEIIIYQQQgghJo8GQoUQQgghhBBCCCGEEJNHA6FCCCGEEEIIIYQQQojJ8/9RYYgjf1kGVgAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$\\displaystyle \\left(- L + r_{i}\\right)^{C} \\left(- L + r_{j}\\right)^{C} \\left(r_{i} {\\gamma}_{1,0,0} + r_{ij} \\left(r_{i} {\\gamma}_{1,0,1} + {\\gamma}_{0,0,1}\\right) + r_{j}^{2} \\left(r_{i} {\\gamma}_{1,2,0} + r_{ij} \\left(r_{i} {\\gamma}_{1,2,1} + {\\gamma}_{0,2,1}\\right) + {\\gamma}_{0,2,0}\\right) + r_{j} \\left(r_{i} {\\gamma}_{1,1,0} + r_{ij} \\left(r_{i} {\\gamma}_{1,1,1} + {\\gamma}_{0,1,1}\\right) + {\\gamma}_{0,1,0}\\right) + {\\gamma}_{0,0,0}\\right)$"
+      ],
+      "text/plain": [
+       "         C           C ⎛                                                      \n",
+       "(-L + rᵢ) ⋅(-L + r_j) ⋅⎝rᵢ⋅gamma[1, 0, 0] + r_ij⋅(rᵢ⋅gamma[1, 0, 1] + gamma[0,\n",
+       "\n",
+       "             2                                                                \n",
+       " 0, 1]) + r_j ⋅(rᵢ⋅gamma[1, 2, 0] + r_ij⋅(rᵢ⋅gamma[1, 2, 1] + gamma[0, 2, 1]) \n",
+       "\n",
+       "                                                                              \n",
+       "+ gamma[0, 2, 0]) + r_j⋅(rᵢ⋅gamma[1, 1, 0] + r_ij⋅(rᵢ⋅gamma[1, 1, 1] + gamma[0\n",
+       "\n",
+       "                                           ⎞\n",
+       ", 1, 1]) + gamma[0, 1, 0]) + gamma[0, 0, 0]⎠"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Concrete example for N_en = 1 and N_ee = 2\n",
+    "f12 = f.subs(N_en,1).subs(N_ee,2).doit()\n",
+    "f12"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Constraints\n",
+    "\n",
+    "$l$ is index for electron_1 - nuclei distance variable\n",
+    "\n",
+    "$m$ is index for electron_2 - nuclei distance variable\n",
+    "\n",
+    "$n$ is index for electron_1 - electron_2 distance variable\n",
+    "\n",
+    "The Jastrow factor should be symmetric under electron exchange (swap $l$ and $m$) \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 124,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAIQAAAAVCAYAAACHfkZBAAAABHNCSVQICAgIfAhkiAAAAtVJREFUaIHt2E2IFEcYxvHf6iIEFaKnQAR3JR4UQQW9RJTxAwIJSAwGLyqeBMWDh6AYEFavIsgi4k28COJFEJKLAS/Chggml5CAIogo+K3owcRED9WDM2NPd81Wz846zh+K6amuevp9H96uru6hsbExAwbUmdFw/B3+xa9Y2Gb8EbzB7i7H9SHRV77NrNVq9eP5+Bw1zMJPLWMX4RyuY6+Q4IA+82244fgqtuARVuWMHRcS3ov/ux9a19iPTzsY/zsuFpzvK9+GW/6/wp9Y0tK/Gd/gNK5NQVzdZL/2S3seZxUXBH3k24ycvr8wFwuy/5/gBB7ix6zvEH7DczzAJSzr4Lrrsjl3hSV0a6eBJ8QwgqEO2q7IeGJ8S8071fdSjXYFAUsbBEZxEE+yvhpO4UtswGtcFp6nMczGH9gXOT6P1BiqJsa31Lxr0nMu1Gh9ZNCc2E0cwATONIz5qmXODjzDGqHiyvg5aylMNoaq9xB1YnxLzTvV91KNsoLYJBRN2e54rrDaPI4MqhvExtCNPQST8y2VKnxv0sgriBv4D98Ld9JJ4ZWpiBPCnTSREFgqsTGMdOn6k/EtlSp8b9LIK4h/cAtf4D4OlwgeEzZLawVDesF0iKFT31KpIuf3NPI2lbxb/g7iaYHgcezERuEO6QXTIYY6sb6lUkXOuRp5KwTMEz6iXCgQHMc2rBfewXvBdIihkRjfUqki57YaeQUxhOX4Gy/bCJ7CdnwrbEY+y/pfZK2MOcLSWmcEKzKt2xHzq4ihamJ8S827ipwLNfIeGYuzwIs2RHuE3ekvuNfQfmgYs0vYYY/kzF+V6devcSw7Pho5PzaGqSTGt9S8U30v1chbIVZmv0WJDRWcqzMqLEd3cs5didAomh8bw1QS49sVaXmn+l6qkVcQ57OWytfCF7nXPZo/1fSFb+02lVWwusfzP1R66lu7184BHymDghjQxKAgBjTxFn96ARMYHPsHAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$\\displaystyle {\\gamma}_{2,1,2} = {\\gamma}_{1,2,2}$"
+      ],
+      "text/plain": [
+       "gamma[2, 1, 2] = gamma[1, 2, 2]"
+      ]
+     },
+     "execution_count": 124,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# How do we use this to simplify the expressions above?\n",
+    "Eq(gamma[l,m,n], gamma[m,l,n])\n",
+    "\n",
+    "# Brute force - loop over m and l<m and create the substitutions (next cell)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 125,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA6wAAAAdCAYAAACuReEJAAAABHNCSVQICAgIfAhkiAAADKlJREFUeJztnXusHkUZh58iFmtRICACEq0KRS7hFKjEEKkQQQ1GRQLhH6knJQo0BgwJGkwhp8YIinJRCIoGDqAG0BqJFwImgmiRi1UEFFAbjogSEKooYqkC/vHupvvt2fl2ZndmZ3e+90lONt395tLfzPvbnd3Z2QUzMzMoiqIoiqIoiqIoSt/YJnYFEmQK+CbwGLAZeAS4Ftg/ZqUSRvVWFEVRFEVRlETRAatfVgIbgOeBE4Gl2T6A02NVKmFUb0VRFEVRFEVJGNOA9RrgSWBxh3XpO4cALwEnG44fBlwJnAWsAtYDjwI/A04CzjakU62rCaU3wCv8VVOJhMaN4ps6zxkK6m/DR/1N8U0q/tYnFsWuQKJU6lo1YF0OfAg4H/h3gIr8BAmawwPkHZINwPeAzwDbVxy/GLgDuMiQflPFPtXaTAi9AU5FL+iGTui4USaTOs8ZAupvw0f9TQlBCv7WN94HLIldiQSp1LVqwPpZ4J/A5QEqsQA4GHgR+HWA/ENzHrAb86ebvgV4K3CZY36q9Xh8630sovc/2ldNiUjIuFEmG5PnDAH1tzRQf1NCMWR/6yPfAc5BbxL6plLX8oB1KXAUcAPwnwCV2BvYAXgYeNZDftPIE8QjPORlw93AQ8ApwMsK+5dl2w0OeanW9fjUeyFwGvAtP1WbWKbpvh8UCR03k8Q0cduyj5g8x5Zp4miq/taeaeLHg/qbH6aJ35Z9ZKj+1ldeBNbR/gbANKprkUpdywPWVciTuesDVeKQbOsy0AjJkUgnuQA4FLgRmUr6EuZVZq8DXo+cVHLy+dYuA0PVul5r8Kf3qcCtHup2HPBf4C7gDYb81mZpP+pQv0mgaR8oUhc32pbhSV23Ks/piqYxYvI31/xSb9uQhPY3bctuSF23WP6Wqq43I4t97hih7FQ1hQpdywPWo4AXgDsDVWB5tv1loPxdOTjbHoAs1vMi8FXkLvVDhjTrs+3RhX0PZNsVhjSvrNinWtdrDf70PgN5f6Nt3Z4AfoxcMHyiIq83ZfvvAb5uKG9SadoHitTFjbZleFLXrcpzuqJpjJj8zTW/1Ns2JKH9TduyG1LXLZa/parrC4imH45QdqqaQoWu2xYOLkamWj5IuBf9+zqIejvwDuwGj/dk2xWlfT8CLkUGS+uROxqHIHc11gC/KPxetbYfqPvQ+yDgtcDvPdRtPfBB4Gm2alzkS8j0vNXIBYWylaZ9IMcmbrQtw5O6blWe0xVNYmScv7nml3rbhiS0v2lbdkPqusXyt5R1/RWyUNolHZebsqZQ0rX4hPV1yJz2xwMVvA1yYn0BuDdQGa7kJ4AzsD+5PANsRqZUFDkO+AJwJvL/uwe5s7Ge+Yseqdb2+ND7cOA+zAHrWrfngd8B+5b2vx94L3AF/blR0Cea9oEcm7jRtuyGlHUzeU4XNImRcf7WJL+U2zYkof1N27I7UtYtpr+lquu9yFPO7SKUnaqmUNK1OGDdOdv+3ZBwDnmKZfv3jVL6pcCrkKkrTZ4qVpV/VXbs1opjszX5Lc7q9OSY316GrFZVZhOwS2nf88DngQOzvHdCnvidi5hDkTqtoZ3eQ9T6POAWw7G2eu+HTJ1oWreqfvAQovGe2b8XIZ/aeQr4lCGfoTGHv37QROdyn6iLG21LM3P4jWlIW7cqzykzRz980uRvNvnBZMbEHPGvJ1z8TdvSzBz+vQ3S1i2Gv+WkqOsTyJPMN1r8dg49F9syomtxSnC+Ip1peeaNzB8IjOOvpX+3naJ6MfNfal4GfAC4GukEReqeLE4hA/YfYn7ytgZ5obnMItqt4FenNbTTe4hafw55IlxFW733wPxd1qb9IH9naD/gMeBsJKhOZvSCYwVwFjKY3h04geqbIONYneWxO/Bb4OPIO0yh0/vsB010LveJurhJvS3blO87psFeN4jXh6GZbjae0xefNPmbTX4QNyZixVQfridc/G0S2rJp+hDeBt35WwzdYvhbzlB0dSn/mWy7B/Xvq0/yudg1/YiuxQHrk9l2Z6p5p0OFqsgHUU1Xrb24Yt800sizwG2O+eXTa+4a85uqO53bIJ3tEcfyitRpDe30HqLWpm8H+tB7MfAnw7Gm/aBoEBuR6ch3svVOWbHs32T719lUtsSJyPz91cDPkU9X3JSV+2jg9D77QROdy32iLm5Sb8s25fuOabDXLWYfBnfdbD2nLz5p8jeb/CBuTMSKqT5cT7j42yS0ZdP0IbwNuvO3rnWL5W85Q9HVpfx/ZduqBT/LTPK52DX9iK7FKcGPA38D9rEotAn5Z1b6Mpc6PwGY6rMn8ji+rMc+yLLzbd4NVa1H2RHReqrimA+9t2B+Kte0HxQN4hJktsLq7LdFbkLuen/Xob5FzkRM7GvIYhynI/3ntI7S+8JV56o+URc3qbdl2/J9Y6tb7D7sqpsPz2lCU580+VtdfhA/JmLHlC9C+9sktOWk+lvXusXyt5yh6OpSfu6/WxqW1ZahnItd04/oWhywvgTcjsxr38uycFv6ugjQFuB+w/FlwHPAH0r735Ztb21Rtmo9yjJkGtODFcd86L0JeHWLulX1gz8iGp+AvNh+OfMXe2rLQuTmQ/mdtVuAwzpI7xNXnav6RF3cpNyWfcRGtyH2YR+e04SmPmnyt7r88jxjxURb+hRTof0t9bbsI134Wwxi+VvOEHR1LT/3X9OrZ6EZwrm4SfoRXcvfYc0fm7/bonAX9kUez28Gvox8D6j8d77nMsexHXIn4n7Md0SmqF558V1Ix7ixZR1U663kS/lXHfeh90aqP+rcph9sQabU7IhM5TqnRf1M7IKsGlleUOUJYLcO0vuiic6mPmGKm9Tbso/Y6DbEPuzL411o45NV/maTH8SNibb0JaZC+9sktGUf6cLfYhDD34oMQVfX8nP/3RiyUmMYwrm4SfoRXbctHVyXJV6JrDbni3yK6mLkJeAqbvZYXh0HAC9n/Duey5j/hHIH4FjgB8CfW9ZBtd5KldbgT++7gFWe6wYyDWMv4JOY38H1QXlax4KKfSHTt6WJzibdTXEzKW3ZN2x1G0of9unxLrTpv1X+ZpPfuDyhu5hoS+yYCu1vk9SWfaMrf+uKWP5WZii62pa/P/Id7HFf/gjNUM7FLulHdC0/Yd2CzH8+FJlW6otrskqN+3tPg3xns7S3OabbkKU7Zcxvpphv/iuROdVfdCyvCtV6K1PIy/FlfOn9U+SzN69pWDfTRcBOyN3sb7esn4mnkDuh5btPu2L+TI/P9FXM4t4Pmuhs6hOmuEm9LUMwS7OYLlKnWx/78Djaes4s3ftklb/Z5JfnGSsm2uK7b8zS3fWEi79NQlv6Zpb23gbh/a1rYvlbmb7r6lr+Qcg7s02ZJf1zcZP0I7qWB6wAFyGrNX3aogKpshh4M6PmvwhZKnodbks4j0O1ljvH+zH/5O1T72eBG4AjHNNV9YOcBcgFwsM0+9atDVuQi5WjS/uPBu7oIH1XlHU29YmcJnEz9LbsIza6DakPh/B4X4yLiaH6W1uGElOT4G8p0oW/dUlf/G0IurqWvwK4MnSlxjCEc3GT9CO6lqcEg7z7eBJwJGKCk2hwB2bb4gIHS4ArsP84sg2qtZy4FzL/RLsEv3qvBS7E7Q5zVT/I2RvYnvrFK7ZndAGNJcjUrU3YLQN+IXAtcDewHrnLvgfwFYu0PtJ3QVlnU5/IaRI3KbRl2/J9Y6tb7D5sq9sS/Hu8L+piYqj+FjumumBS/C12et905W9d6baEfvjbUHS1LX8pMr36Pst6hWAo52KX9PN0rRqwgqxUd7tlBVJkCpk3/Vxh34PATICyJl3rZcBfgKdL+33rPYesnrgUaVsbqvpBTj5dq84gljO6Gt8F2fZq5NtbZNurkA89z5XSX498l28N8qHlB4BjGP3uYtv0sSnrbOoTRVzjJoW2tCm/S2x166IPj0tvq1soj/dBXUzMMUx/6yKmYjMp/tZF+i7pyt+60q0v/jYUXW295SPEX8hsKOdiF7+ep+uCmZmZsf87RQnMpcgdluM6KGshEgDn0q8FEdYCxyMXHf+LkL5vdNknfKNt2QzVbTw2MaH+NgzU39JpS1tUtzDE1nU58hT3ugZp+0psTcGga9U7rIrSBYuQTnk87V5WdyFf0GLXjsqz5RjgYzQP7rbp+0KMPuEbbctmqG7VuMSE+lu/UX9Lpy1dUd3CEFvXzaQ1WIX4moJBV33CqsRiDXAq8H3gdOQj6spko31CUUbRmEgHbUtFUZSG6IBVURRFURRFURRF6SU6JVhRFEVRFEVRFEXpJTpgVRRFURRFURRFUXqJDlgVRVEURVEURVGUXvJ/kL7qS8xmvmQAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$\\displaystyle \\left(- L + r_{i}\\right)^{C} \\left(- L + r_{j}\\right)^{C} \\left(r_{i} {\\gamma}_{1,0,0} + r_{ij} \\left(r_{i} {\\gamma}_{1,0,1} + {\\gamma}_{0,0,1}\\right) + r_{j} \\left(r_{i} {\\gamma}_{1,1,0} + r_{ij} \\left(r_{i} {\\gamma}_{1,1,1} + {\\gamma}_{0,1,1}\\right) + {\\gamma}_{0,1,0}\\right) + {\\gamma}_{0,0,0}\\right)$"
+      ],
+      "text/plain": [
+       "         C           C                                                        \n",
+       "(-L + rᵢ) ⋅(-L + r_j) ⋅(rᵢ⋅gamma[1, 0, 0] + r_ij⋅(rᵢ⋅gamma[1, 0, 1] + gamma[0,\n",
+       "\n",
+       "                                                                              \n",
+       " 0, 1]) + r_j⋅(rᵢ⋅gamma[1, 1, 0] + r_ij⋅(rᵢ⋅gamma[1, 1, 1] + gamma[0, 1, 1]) +\n",
+       "\n",
+       "                                  \n",
+       " gamma[0, 1, 0]) + gamma[0, 0, 0])"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 0 0\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAVCAYAAAANfR1FAAAABHNCSVQICAgIfAhkiAAAAiBJREFUWIXt1k2ITlEcx/HPjGlKKCIhYbws2DAZFordbEYpIlsrMsnCwkTU2NgoGQuEQlaTsrGYGgs25LVJyUspL4lGEzaK8TIW58rtznmeex/XYyK/ut3nnPP/3/v9Pefc/zkN3d3d/kU1pn5vwGfcxNwK8Qcwgq115iqttLFBXMZK7I7Ezk/6b+N0/dHKKW3sGtbjA9oisUfRjE58qz9aOTVm2p/wAIsz/euwFidx5w9wlVbWGDzCJMxO2uNxBEPYm4rrxFN8xF2sruG9a3AJr4RvdmNN1AUYKhmDJcl9D1rQhXdJ32b04CBahWXchzkFgSbgHnYUdRBRVYY8YwuEgnEDZ1Ixu3AWp/AQO/Ea2wtC9WEfLha2MVpVGfKM9aBJmPKRpL8Zy9GfyevHqhKgtSiXIWbsCb5ik1AwjmMgNT4N44TtIa1BzCiNXEy5DDFjw8IHORlvsL/Cw0cy7YZIX71VkSFmjJ/LsQvvM2NDwoxmZ2e60f9gvZTLUMnYFGETvhAZGxZKa3umvx3Xf5W0RuUyNEWSGrAUj4VTSEyHcR63hDK7DbNwoiDYRCxMtedhGd7iRcFnVGWIGVuUvHggMvZDvZgqlOyZuI8OPE/FbBG2iBY8y+S34UqqfSi5n0vy8vJzGWLGWpN7NWNwLLkqqUU4nr2MjF0VVkY1VcvPZYgZ602usuoQThZfxiI/Zux3acVY5leqin+9/hv72/Qd+sqEaRwOP9QAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$\\displaystyle {\\gamma}_{0,1,0}$"
+      ],
+      "text/plain": [
+       "gamma[0, 1, 0]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAVCAYAAAANfR1FAAAABHNCSVQICAgIfAhkiAAAAhVJREFUWIXt1k2IjVEYB/DfHdOUUERCwvWxYMNkWCh2sxmliGxnRSZZWJiIurOxUTIWCIWsJmVjMTUWbMhnUvJRykei0YSNYnyMxXnL2+u997733veaRv71ds553uf5n+ffOec5p1AqlfyLaIn1t+AbbmNhGf8+jGFHk/NqGHFhw7iKtdiX4rs4st/F2ean1hjiwm5gMz6jI8X3ONrQg5/NT60xtCTGX/EYyxP2TdiI07j3F/JqGElh8BTTMD8aT8YxjOBAZNuAK3grnLmtdczdgxf4gvtYnydHOWGwImr3o4hefIxsU/AQu+tIBrajH4fRLhyDQSzIi6OasCVCwbiFczGfQRzE5RoSiWMvzuMMnmAP3mFXXhzVhPWjVVjysRqTL4c2rMZQwj6EdXlxpAl7jh/YJhSMk3iQccIsmIVJwvUSxzDm5MWRJmxUOJDT8R6HMk5WK5I7oJBiq5sjTRi/t2MvPtU4WTWMCDsiuTqz/bkCdXOUEzZDuIQvZZyoFowKpbkzYe/Ezbw4WlOCCliJZ8IrJA1TsTQ2XoRV+IDXGRI7iou4I5TpnZiHUxliM3GkCVsWJV6pYHTgWmx8JGovoDvqdwtXRBEvE/EDmClcGXPxCF14FfOpFF+VI01Ye9RWEnZdWNlKKArPszdl/p+IvnrjK3KkCRuIvkbRJbxMvo9HfJqwvLBmPOPLVcUJj//CJhp+AS0OhGkOAJ8DAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$\\displaystyle {\\gamma}_{1,0,0}$"
+      ],
+      "text/plain": [
+       "gamma[1, 0, 0]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 0 1\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAVCAYAAAANfR1FAAAABHNCSVQICAgIfAhkiAAAAg9JREFUWIXt1k+IzVEUB/DPG1JCjZIkMSMWbJgMC8XKLIxSRLZW5CXJwkTUY2GjZCQJRVlNlhZTY2ND/jZsRJFIajRhoxh/xuL+Jr9+7vvn957XyLduv3vPPefc8/2de8+9hVKp5F9EW6q/FV9xF4vK6B/DOHY1Oa7cSBMbwQ2swcGI7uJEfh+Xmh9aPqSJ3cIWfEJ3RPcMpqGIH80PLR/aMuMveIJlGflmbMIFPPgLceVGlhg8xSwsSMbTcRqjOJzSK+IlPuMh1tWx7npcx1vhzG6rK+oafJQjBsuT7yF0og8fEtkO9OMEuoRtPIiFNQY1A4+xt0b9un1MjcjSxF4IBeMOLqd0DuAKLibjfdiIPcKPqIbBpOVBRR/VMtYvkC8K6SYUkFUYytgNYW2eSBuJWMae4zu2ox1nMZyan4MpwvWQxgg2NCHGP0IsY2NCUWjHOxwtYzueGRcispYhRoxf27EPHzNzo0JG52Xkc/2exZahHLHZwiV8LTI3JpT3noy8B7cbF1o+xM5YASvwTHiFxHAKV3FPKPW7MR/na1x3Jpakxh1Yifd43QgfsYwtTYyGI3MTGMB+HMEj4XLuxauUzk7hzHVE7LsT/xNrnEz6x2u0r+ojlrGu5FuJGJxLWjl0Cs+zN5G5m8LOqIRK9lV9xIgNJC0veoVXwbdW2MeINQqrW2lfripOevwnNtnwEyoXcdRtkQDsAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$\\displaystyle {\\gamma}_{0,1,1}$"
+      ],
+      "text/plain": [
+       "gamma[0, 1, 1]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAVCAYAAAANfR1FAAAABHNCSVQICAgIfAhkiAAAAhBJREFUWIXt1k+ITlEYBvDfDE0JNUqSxIxYsGEyLBQrszBKEdlakUmShYmoYWGjZCQJRVlNlhZTY2ND/oaNKBJJjSZsFOPv4pzJ7TrfnW++745p5KnTvee97/u9z/O95z3nNPT09PgX0Zh534KvuIOFFfyP4id2jjOvupEVNojrWI0DCd9F0X4PF8efWn3ICruJzfiE9oTvaTShCz/Gn1p9aMzNv+AJlubsm7AR53H/L/CqG3lh8BQzMT/Op+EUhnAo2tbhGt4KPbe1htxdeInPeIC1Y4wv5FBJGCyLz4NoRTc+RNt0PMaeMZIZwXb04jjahDbox4Ix/EYhh6kJW1bYC2HDuI1LGZ/+OGrFflzGhTjfiw3YLfyR1aCQw2gV6xXEdwnlLgNNWImBnH0Aa0rKkazYc3zHNjTjDB6WlRCzMUU4XrIYxPqykqQqNiw0dTPe4UhZyXLIr4CGhK1mpITxezl242NZySKGhBUxN2ef488q1oxKwmYJh/DVshJlMCxs7x05ewdulZUk1WMNWI5nwi0khRlYnJm3YAXe43UVeU/iCu4KW/0uzMO5akhXwyFVsSUxqGjDaI/fR3xOxPdjGZ8dQs+0JOL7sA+H8Ug4nDvxqsr4UTmkKtYWn0XCbgiVLUKrcD17U+H72ThqjS/kkBLWF0e96BRuBd8mIj4lrCysmsj4SrvipMd/YZMNvwCgDHHU2MQHcQAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$\\displaystyle {\\gamma}_{1,0,1}$"
+      ],
+      "text/plain": [
+       "gamma[1, 0, 1]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 0 2\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAVCAYAAAANfR1FAAAABHNCSVQICAgIfAhkiAAAAltJREFUWIXt1k2ITlEYB/DfDCkxhSRJzIgFKSYfCxr5moQSIhtkRSZJkomoYWEzEdIkFGUlSws1KBvy2bARRSIRJl9RjGEszn25Xed9551eMxP51+ne83yc8/zv85zn3LKGhgb/IspT78vxFdcxOo/9HnRgfTfHVTLSxF7iAqZje8R2TCK/iRPdH1ppSBO7gmX4hKkR28Pohzp87/7QSkN5Zv4F9zA+I1+CxTiGWz0QV8nIEoP7qMDIZN4fB9GKnSm7OjzGZ9xGTRf2nYVzeC6c2RVdijpgh3AsPuB1st7EnDIfMZiQWqAK9XibyFbhEPahWijj8xhVZFADcBebirSPYTaaMANz0Y6LGAJ9Iw5pYo+EhnENJ1M2W3EKx5P5ZizERuFDdIbzySgFCzLzNXiPmTjXWcYOCeTrhJIhNJApaM74NQtfr7dQIVTgG+IZe4hvWIlBOIKWlH4o+gjXQxovMf8PB9sVHMQdobqixNqEpjAWr7A7z0IdmXlZRNZTaBQaUo2QlGjz4Fc51uNdRteaOA/PyIf5PYs9gf1Yi3lCtSE/scHCJXw2omsT2nttRl6LqyWH2TUcxmrMEe7fn4iVYhkm4YHwFxLDAZzGDaHVb8AIHC0yoIFCqedQicnCwX9a5BpNAqmliV+ugj7iYyxj45KNWyK6HM5gC3YJB7YGi/AkZbNOOHOVEf+pyfq5PRqT971F+hOulgpcwovU2EY8Y9XJsxAxwhdrKqCvEsrjWUR3WaiMQijkrzP/GLEzySgVi4Q/i/be8I8R+1OY1pv++briX4//xP42/AC0l4CuNplnLAAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$\\displaystyle {\\gamma}_{0,1,2}$"
+      ],
+      "text/plain": [
+       "gamma[0, 1, 2]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAVCAYAAAANfR1FAAAABHNCSVQICAgIfAhkiAAAAlxJREFUWIXt1luITlEUB/DfoCkxhSRJbvFAisnlgUZuk4wSIi/IE5kkSSaihgcvEzFpEoryJI/zMDUoL+QaXkSRSDRMbo1ijMvDPh+n43zffJcZE/nX7py99l57rf9Zl33K6uvr/YvoF3tfhS+4jrFZ9u/Hd2zqZb9KRpxYGy5gNnal7J0QyW/iVO+7VhrixK5gJT5iZsreRpSjFt9637XS0C8x/4z7mJyQL8cynMCtP+BXyUgSgweowOhoPhBH0I49kWwemvFCqLnVRdiuxRN8wm1UFai/WyiLD3gd+TM1s5iNGEyJHTAedXgbyQbhHrYW6EwGa3EUB1EplEELxhRwxnw0YQ4WogsXMQwGpCjEiT0WGsY1nI7taYlGsdiBMzgZzbdhKbYIHzIfLEnM1+M95qK5u4gdFcjXCinXEyjHDLQm5K3C1y8WFUIGviE9Yo/wFWswBMdwpwSDSQxHf+F6iaMNi0s49wjuCtmVSqxTKOqJeIV9JRjLhWQGlKXI8kWD0NCqhKCkNg9+pWMd3hVpLBvaI+MjE/IRfo9iPjiEDVgkZBuyExsqXMLnizDUHTqF9l6dkFfjaoFnNWIdFgj370+kpWIZpuGh8BeShsFCqmYwDtOFwn2Wh0OHcRY3hFa/GaNwPA/dDJoEUisiu5kM6EBHWsQmRY7nahgzo/XMnobo/UBsz0ahZsal6J/DduwVCr4KNXiapz7haqjAJbyMjZ2kR6wyeuYidlmIbC6MF9LjeZb1pmgUq5/Tfhqxc9EoFTXCn0lXX+inEespzOpL/Wxd8a/Hf2J/G34AKpuArjT88iwAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$\\displaystyle {\\gamma}_{1,0,2}$"
+      ],
+      "text/plain": [
+       "gamma[1, 0, 2]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 0 0\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAVCAYAAAANfR1FAAAABHNCSVQICAgIfAhkiAAAAkxJREFUWIXt1k2ITlEYB/DfO6YpZRYkScKIBSnJx0KNfGQzSkzJRrJBJgtKJqLGxkY0M4sh2VkJKwvlY0nGRyNFREkpDfIVxTDG4tzJ7Trve+/rNUT+dXrf85znuff/P89znnNLHR0d/kXUpf634jN6MbWM/wEMYcsI86oZaWH9uIhF2B3xnZ7Yb+DEyFOrDWlhV7AWH7Ag4tuNBrTh68hTqw11mfkn3MOsjH01VuE4bv4GXjUjKwzuoxGTk/lodOIl9qb82vAYH3ELzVW8d49Q0u/wAucwpxrieRzKCYPZKRJNaMfrxLYeXTiIeUIZn8eUgoSWogeLsRxfcAnjCsbncihF2n0rzmKnsJN30ZeQGEp8enEHm1NxD3FG2IhqMQZvsSZ5ZxFU5JCXsS7UCykfFtWA+biQibsgiP8ZNArV86qgfy6HmLBHGMQ6oWEcFTI2jPEYJVwPafRjYkFiWXTiNq4V9M/lUB8JGhAO5Aw8x/4yDx/KzEsRWxEcwhLh4A9WGVuWQyxjfC/HdrzJrL1MCGSzM8GPO5iHw9iIFUKlFEUuh3LCxgqX8OnI2oDQWldm7CtxtQpy3diAZcLdWQ1yOcRKsYS5eCB8hcRwBCdxXWizWzEJxwoS6xFErREaxvDOv09GEVTkEMvYTKH99kXWhnEKO7BPOPTNaMGTlM8mod6nReK3CZ3wMp6lxq6C8bkcYhmbl/xWEkbY9Z4K601CiT2NrJVynp0Xn8shJuxUMmpFC7YLXxW/PT4m7Fdh4Z+ML9cV/3r8F/a34RsFw5Zr3Y2Y9QAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$\\displaystyle {\\gamma}_{0,2,0}$"
+      ],
+      "text/plain": [
+       "gamma[0, 2, 0]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAVCAYAAAANfR1FAAAABHNCSVQICAgIfAhkiAAAAkhJREFUWIXt1l9oT2EYB/DPb9ZKcUGSJExckNLy50JN/rSbKc1KbiQ3yHJByZqouXEj2nYxkjtXC1cu1HBJ5k+kiCgppbH8i2LMXLxnOf12zvmd7bdNk2+9nXOe8z7f83zf53mf9xRaW1v9i6iI3TfiB3qwIGX+cQxizzjHVTbiwnpxDWtwOGHuosh+F+fHP7TyEBd2E1vxFasS5nagCk34Nf6hlYeKoufveIKlRfYt2IxzuDcBcZWNYmHwFNMxL3qeijb04UhkaxFK8jPe4QqWj/DbTXiJb7iP2hH6Z3KkCYNl0bUF1WjGh8i2Hp1Yi434ieuYmTOg7WjHCdQI2+Aq5uf0L8lRSGj3jbiMg0ImHuNBJGIw5SPT8AkNkU8p9OARdsdsz3FJWMg8yOQolbF2VAopTxNFKN0KvM8RUBVWorvI3i0sXh6U5EgS9gID2CY0jDNCxrLQhoe4nSOoWZgiHC9x9GJODv9cHJUJTv3ChlyMtzhW4iMnsU7YuAM5A2N4BRQSbKPmSMoYf8qxGR8ziE9hJzYJmc6DPmEBirMz2/AMjJojTdgM4RC+mEHegR3YIJx9edEvtOa6Insdbo0VR1IpFrACz4S/kCR0CqIahIYxtHJfolEKp3EBd4Q2vRdzcTaHby6OpIwtEdp3VsPYJ3TCG3gTG4dic3YJ9b4wwb8LB3BUaDq1qMernP4lOZIyVhNds4QVMt4NoVoo0dcp7zujMVr/TI4kYV3RKBf12C/8lUy4f5KwscLqv+mf1hUnPf4Lm2z4DeillmsjApCVAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$\\displaystyle {\\gamma}_{2,0,0}$"
+      ],
+      "text/plain": [
+       "gamma[2, 0, 0]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 0 1\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAVCAYAAAANfR1FAAAABHNCSVQICAgIfAhkiAAAAmFJREFUWIXt1k2IjlEUB/DfICUUkiQxxIIU8rGgkc9klBDZICuaSZJkImpY2ExkJk1CUVaTpcXUoGzIZ8NGFIlEg3xF+R6L+0yenrnvvO/M+w6Rf92e555zz73nf8+5596y2tpa/yL6pP5X4yuuYWyO8fvRjs297FfRSBNrw3nMxq7I2PGJ/AZO9r5rxSFN7DJW4SNmRsY2oD+q8aP3XSsOfTL9z7iLSRn5CizHcdz8DX4VjSwxuIfBGJ30B+AIXmFPalw1HuETbqGiG+vuFlL6PV7iHKZ0x3HMS+yeCed+TVqZixhMTjkxDjV4k8jWoR4HMV1I42aMKdCp+WjEHCzEN1zAsALtYSDuYGtM2S8iSxN7KBSMqziVGrMDp3Ei6W/DMlQJG5EPSzP9DXiHuUIUCkFz0qLIF7F6gXy1EG5CAZmBloxdixCBnmBw4svrHtp3QixiD/AdazEER9Ga0g9HX+F6SKMNi3voxxHcFjKjJIgR+yIUhQl4gX05bNsz/bKIrBDUCYWgQtjQkiCWivxKxxq8zeheJQ6MzMhH6BzFfDiEjVgkZErJkIvYUOESPhvRfRHK+5KMfAmudGPtBqzHAuHuLCliqViGqbgvvEJiOIwzuC6U+i0YhWMFrtsokFopFIyO6H9IWiEYJByXDpRjWjLfk1jEJiZGrRFdB5qwHXuFQ1+BSjxOjdkknLnyiH2VUAkv4nmq7SzQnvDsa035WZf8HyAesenJtytihF1v7EI/TkixpxFdWZ6589nDpa7miRFrSlqxqBReBd/+hH2MWKkw60/a56qKfz3+E/vb8BOg44CuAwwY6gAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$\\displaystyle {\\gamma}_{0,2,1}$"
+      ],
+      "text/plain": [
+       "gamma[0, 2, 1]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAVCAYAAAANfR1FAAAABHNCSVQICAgIfAhkiAAAAmJJREFUWIXt1luITlEUwPHfN6SEQpIkt3gghVweaOSajBIiL8gTzSRJMo2o4cHLRDOTJqEoT/LoYWpQXsi14UUUiUSD3KJcxuVhn8npON/3nZlvxjTyr905Z+299llrr7XX3rna2lr/ImWx97X4husYl2f8AfzE1h62q2TijrXhAuZiT8rYiZH8Jk72vGmlEXfsCtbgE2anjG3EAFThR8+bVhplie8vuIcpCfkqrMRx3PoLdpVM0jG4jyEYE30PRD1eY28kqxFS8gNe4TymdfLfVXiMz7iN8k7qL4j++1zY9+vinfkcg6nRswYTUI23kWwhmjAPi9GOixie0agNaMAhzBS2QTPGZtSHQbiL7Wmd/VNkccceCQXjGk7FxixP6GzCe8wXVrEYu3AaJ6LvHViBSmEhs9ActVSKRaxBcL5KCHc+hkRzvclg0ADMQktC3iJkQLeQFrGH+I71GIqjaC0yTz3uCJEtxgj0E46XOG1YmkE/E2mOfRU29SS8xP4ic9QJG7lcWJCsJDMglyLrMmmpyO90rMa7AvqHsRlLhEhn4bWwAKMS8pH+jGKXyefYMOEQPldAtxEbsUg4+7LyVSjvyxLyZbjaiXkKkpaKOUzHA+EWkkaT4NRqoWB0rP7HqBXjCM7ghlDqt2E0jmU1HIOF7dLBeMyI7HmaFrHJkVKhglEpVMJLeBFru2Njtgh7ZnyK/lnsxD6h6JSjAk8y6hOufa0xO+ui94OkR2xm9CzkWK5AXwcThBR9lqe/KWpd1b9cyI40x85GrVQqhFtBe2/opznWXczpTf18VbHP89+xvsYvyBSAribIhn4AAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$\\displaystyle {\\gamma}_{2,0,1}$"
+      ],
+      "text/plain": [
+       "gamma[2, 0, 1]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 0 2\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAVCAYAAAANfR1FAAAABHNCSVQICAgIfAhkiAAAAk1JREFUWIXt1l9ozWEYB/DPmbVSFJIkYeKClJY/F2rybzdTmpXcSG6Q5YKSRdTcuBFtS0ty52rhyoUaLsn8aVJElJTSWP5FMWYu3t/Jz9l7ds7OsWnyrbdz3ud9nu/v+f7e533eX6alpcW/iIrU/0Z8Qzfm5vE/hkHsGuW8ykZaWC+uYiUORnznJ/Y7ODf6qZWHtLAb2IzPWB7xbUcVmvBj9FMrDxU58694hEU59k3YiLO4OwZ5lY1cYfAYkzE7mU9EK/pwOOXXhOf4gnuoHcFzDwkl/RFvcBlLRpJ4IY58wmBxiqAazXiX2LaiDcdRI5TxFcwpMqk16MAqrMN3XMO0IuMLcmQi7b4Rl7BfeAsP0ZMQDCY+3XiAnam4p7govIiRYhI+oCF5Zin4jaPQjrWhUii7rKgqLENXTlyXIL4UTBaq522J8UM4KiMOzzCALZiC08KOZTEdE4TrIY1ebCgxqVbcx60S44dwxIT1C01hAV7jaB6iwZx5JmIrBiewWmg+AyXERzlipcivcmzG+5y1viR4Zo59hqG7WAgnsR3rhUopBVGOfMKmCpfwhchav9De63Lsdbg5goTasQ1rhbuzFOTliJViBkvxRPgKieEUzuO20Op3YxbOFJlQR5JQg3DYs7v/KRllc8R2bKHQOnsia1l0Yh+OCAe2FvV4kfLZIZy5eZH4PUIXu45XqXGgyPiCHLEdq0l+hxNGeGMdw6xXC+XxMrKWKcBdKL4gR0xYZzLKRT32Cl8EYx4fE/ansOJvxufriuMe/4WNN/wEw6KR55dFrsMAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$\\displaystyle {\\gamma}_{0,2,2}$"
+      ],
+      "text/plain": [
+       "gamma[0, 2, 2]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAVCAYAAAANfR1FAAAABHNCSVQICAgIfAhkiAAAAkxJREFUWIXt1l1ojmEYB/DfO2ulKCRJwsQBKS0fB2rytZMpzUpOJCfIckDJImpOnIi2pSU5c7Rw5EANh2Q+IkVESSmN5SuKMXNwP8uzd8/7vM+716bJv+7e97me67ru/3VfH/eTa2lp8S+iIva/Ed/RjbkF9I9hALtGmVfZiAfWg6tYiYMJuvMj+R2cG31q5SEe2A1sxhcsT9BtRxWa8HP0qZWHirznb3iMRXnyTdiIs7g7BrzKRn5g8ASTMTt6nohW9OJwJDsklOQnvMVlLClx7ya8wFfcQ22J9qkcCgUGi2MOqtGM95FsDTqwCuvwA9cwLSOprWjDcdQIbXAFczLaF+WQSxj3jbiE/cIpPML9yMFAgU0m4SMaIpti6MZD7IzJnuGicJAjwRAOxTLWhkqhbAoFRSjdCrzLQKAKy9CVJ+8SDm+kGMKhMkHhOfqxBVNwWshYGlrxALcyEJiOCcL1EkcPNmSwz8QhKbA+oakX4A2OFnF4AquF5u8vgUh+BeQSZFkxjENSKfK7HJvxIcXhSWzHeiHTWdAbbT4zTz7D8CxmQSKHQoFNFS7hCykO27ENa4W7Lyv6hPFelyevw80S/KRySCrFHJbiqfAVkoSOyGGD0KyDp/85WsVwCudxWxj1uzELZzLYZuKQlLGFwuhMGxh7hCl0Ha9j60BMZ4fQM/MS7DuxD0eEhq9FPV5mtC/KISljNdFvWmC5lHeDqBbK41WB9x3RGql9KoekwDqjVS7qsVf4Ihhz+6TA/hRW/E37QlNx3ON/YOMNvwCbk5HnMdvigQAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$\\displaystyle {\\gamma}_{2,0,2}$"
+      ],
+      "text/plain": [
+       "gamma[2, 0, 2]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 1 0\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAVCAYAAAANfR1FAAAABHNCSVQICAgIfAhkiAAAAlxJREFUWIXt1l9oT3EYx/HXRiuxQpIkNnFBimVc0OTfkikhcoNc0ZYkyZqoceFm0ba0hKJcLZcuVkO5IX/DjSgSicbyL4qZPxff88vp52z7nf3Mmrzr2znf5zzPOc9zvp/vc05BfX29f5HC2Pk6fMV1TOnB/yB+YNsA55U38cI6cAHzsTfBd2pkv4lTA59afsQLu4K1+ITyBN9mFKEG3wc+tfwozJp/wX3MyLKvxiqcwK2/kFfeZBcGD1CMSdF8BBrRiX2RbRHO44Ww59anfG6dIOkPeB3da1bKexDU8wSfcRsVmQs9FQYzY0mUohZvI9tI3MOOfiQDi9GCBViKblzE2BT32IgmHEaZsJXaMBmGJwTEC3ssNIxrOB3zaYtGf1mRNd+M91gorF4u7MYZnIzmO7ES1ajra8WahOJrBMkNFMWCet7k6F+EuWjPsrcLKkhcsUf4hg0YjWO4049k09CIu4IycmEchgmfqDgdWE5yYV3ChpyGVzjQn0xT0CA0owrhhaYhW0UFGVuSFPklx1q8S/mwNBzBFiwTlJIrncJLmJBlHy9axZ4KGyN8hM+lSjMdzdiEJcK3Mw1dQnuvzLJX4irJUizAbDwU/kKSGCVINUMJ5gib/1kOibUIRa2JYjJv/mM0cuEozuKG0Oq3YyKOk7xi06PEe2sY5dH1jE9DdH4o5rNV0HtJQny10Akv4WVs7MkxHlqxC/uFxlOBKjwlecXKomNvhV0WVrY3SgWJPU+41ldsX/EZWqLxG0mFtUYjX6qEP5PuwYhPKuxPMW8w43vqikOe/4UNNX4CRECArv61WJkAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$\\displaystyle {\\gamma}_{1,2,0}$"
+      ],
+      "text/plain": [
+       "gamma[1, 2, 0]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAVCAYAAAANfR1FAAAABHNCSVQICAgIfAhkiAAAAlhJREFUWIXt1luIT1EUx/HPoCkxhSRJzIgHUsjlgUZuk1BC5AV5IpMkyTSihgcvE5lJk1CUp8mjh6lBeSHX8CKKRCJMblGMcXnY+59/x/lfpr/5i3xrd85ZZ6+91++sddY5FU1NTf5F+mWdr8IXXMXYHPP34Ts29XFcJZMt7AXOYRZ2pcwdF+3XcaLvQyuNbGGXsBIfMSNlbisqUY9vfR9aafRLXH/GXUxM2JdjGY7hRhniKpmkMLiHKoyO1wNxGF3YHW2NQkm+xyucxeRe7Ds3+jwT3tnVvQ08Uo9H+ISbqM3cyCUMJsVjI2rQgDfRNg9tmI0F6MF5DCsyoEG4g61Fzk9jLVpwANOEV6kDY2BAikO2sIdCw7iCk1lzFid81uMd5giZKERHHKWwA6dwPF5vwxJsQWOhjLUI4uuFkslFlZD91yUGWyyVmI7OhL1TqKLUjD3AV6zBEBzBrQIbHcZtIbPlYDj6C5+obF5gEenCuoUXcjxeYm+BTZqFZlArPJBykqyiiowtrRT5WY4NeJtn4YPYgIVCpstFl/AQRybsI8Qs5hI2VPgIn8mzeCvWYb7w7Ssn3UJ7r0vY63CZ9FKswBTcF/5C0mgTRK0QGkbmyX2IoxCDhVLPUI2pca0nRfjDIZzGNaHVb8YoHCU9YxPixvkaxhahE17A86yxM2vORqHeq1P8Z8T1M3s0x/P9RfpDO7Zjj9C4arEUj0nP2LR4zCesIs+9DDVCiT5NuXexiDXy+Wdoi+MX0oS1x1EqS4U/i54/4Z8m7Hcx80/65+qKfz3/hf1t/AD1bYCueZLfFQAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$\\displaystyle {\\gamma}_{2,1,0}$"
+      ],
+      "text/plain": [
+       "gamma[2, 1, 0]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 1 1\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAVCAYAAAANfR1FAAAABHNCSVQICAgIfAhkiAAAAf1JREFUWIXt1k+ITWEYx/HPTFJiCisLZUYsSKGGBZF/pSghskFWymQpE6Xu2E5qmjQLKWtZWligbBRR2IgiJZE/+RcLjD+L97053d5z7r3OuaaRb73d877ned7n99z3Oc85XbVazb9Id+Z6J77hJubl2A/hJw52WFdpsom9xGWsxNGE7fy4fgtnOy+tHNnErmMHPqM/YTuKqRjAj85LK0d3w/wL7mNRw/o2bMUZ3P4LukrTmBg8QA/mxvk0jOANjse1tbiI58Izt6vNuMeEkv6I13GvJW3uUaghLzFYnBHRh0G8i2vTcQ+H2xRTZx3GsAobMI4rmN3GHoUapiTWsok9FhrGDZzL2FyK40/Z3DDfhw9YLZxCKxRqaJbYpmgzIBx3p+gRqudtVRumEnuE79iNmTiNO1UFzGEEd4XKqIRUYl/xBAvwCieqCpbDsNAI1gh/aCWkmge/y3EQ76sKluAU9mOjUCmVkToxmCW8hC9UGayBUezBeuHdWSmpxLqwFA+Fr5AUM4RSrdOLZcLD/7SFuGPYi+3RZ05c/xRHKxRqSJXiwuhU1DD64/26zXC8PpmxOSB00t6E/yGhE17Fi8w40qJ/Uw2pE1sef4sSuyacbBF9Qok9S9xr5tvMv6mGVGLn4yjLFuGrYHwi/POaRxWsmEj/vHY/6fmf2GTjF8ebbjmS8nSuAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$\\displaystyle {\\gamma}_{1,2,1}$"
+      ],
+      "text/plain": [
+       "gamma[1, 2, 1]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAVCAYAAAANfR1FAAAABHNCSVQICAgIfAhkiAAAAflJREFUWIXt1k2ITWEYB/DfnaTEFFYWyoxYkEINCyJfpSghskFWymQp0yh12U5qmjQLKWtZWligbBRR2IgiJZGPfMUC42Pxvjen23vPudeZa+7Iv97OOc95nv95/ud53uecSrVa9S+iK3O+E99wE/Ma+J/ATxxsc16lkRX2EpexEkcTvvOj/RbOtj+1csgKu44d+Iy+hO8IpqIfP9qfWjl01V1/wX0sqrNvw1acwe2/kFdp1AuDB+jG3Hg9DcN4g2PRNii05Ee8xkUsaeG5a2PMc2HP7mo18SKORsJgcTwOohcDeBdt6zCKVdiAMVzB7CaTmo57ONykf8scUxK2rLDHwsC4gXMZn811MfvwAauFt1iES3GVQS5HkbBN0adfKHcjdAvVf/tnOY4/UsIe4Tt2YyZO404BzzDuCpXtCKSEfcUTLMArHC/gGBI28hrhhXQEUsOD3+04gPc58aewHxuFSncMUhWDWcJH+EJO7Aj2YL3w7esopIRVsBQPhb+QFEaxF9uFgTEn2j/FVYQZQqvX0INlketpE/GFHKlWXBiD8gbGIWESXsWLzDqS8TkgTNKeRHxf5K89Yyien2wyvpAjVbHl8ZgnrJJzr4ZeoUWfJe5da4IjL76QIyXsfFxlsUX4KxibiPhGw2M8sGIi4xuN+0mP/8ImG34Bd5duOUtdF4YAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$\\displaystyle {\\gamma}_{2,1,1}$"
+      ],
+      "text/plain": [
+       "gamma[2, 1, 1]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2 1 2\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAVCAYAAAANfR1FAAAABHNCSVQICAgIfAhkiAAAAftJREFUWIXt1k2ITlEYB/DfTFJiCisLZUYsSKGGBZGvUpQQ2SArZbKUiVIv20lNk2YhZS1LCwuUjSIKG1GkJPKRr1hgfCzOeXN7O+9777z3vqaRf53uPec+z/95/vc857m3q1ar+RfRnbnfie+4hXlN7E/iFw52OK/SyAp7hStYiaMJ2/lx/TbOdT61csgKu4Ed+IL+hO0IpmIAPzufWjl0N8y/4gEWNaxvw1acxZ2/kFdpNAqDh+jB3DifhmG8xfG4thaX8EI4c7vGGfeYUNKf8CZyLamSo5kwWJwh6MMg3se16biPw+NMpo51GMUqbMAYrmJ2VRxTEg5ZYU+EhnET5zM2l+NoF5sb5vvwEauFN1+aI0/YJkH8gFBynUKPUD3vquJICXuMH9iNmTiDuyUCFsEw7gmVUQlHStg3PMUCvMaJEsGKYEhoRmuEF1oJR6p58KccB/GhzWBFcBr7sVGolMo4UjsGs4SP8MU2gxXBCPZgvfDtrJQjJawLS/FI+AtJYYZQqnX0YplwcJ8VSGgUe7E9+syJ65/jKIKWHKlSXBgTb9Uw+uPzus1QvD+VsTkgdNLehP8hoYtdw8vMOFLQP5cjtWPL47WVsOvCzrZCn1AezxPP8nzz/HM5UsIuxFEWW4Q/k7GJ8G/WPKrAion0b9buJz3+C5ts+A1k2Hz4bBPB2gAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$\\displaystyle {\\gamma}_{1,2,2}$"
+      ],
+      "text/plain": [
+       "gamma[1, 2, 2]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAADYAAAAVCAYAAAANfR1FAAAABHNCSVQICAgIfAhkiAAAAgNJREFUWIXt1k2ITmEUB/DfO0mJKawslBmxIIUaFkS+SlFCZIOslMlSJkq9bCc1TZqFlLUsLSxQNooobESRkshHvmKB8bF4njd3Xs977ztdr9vIv57uveeec57//55zz721er3uX0RX5nw7vuIG5rTwP44f2N9hXqWRFfYCl7AchxO+c6P9Js50nlo5ZIVdwzZ8Ql/CdxiT0Y/vnadWDl1N159xDwua7FuwGadx6y/wKo1mYXAf3Zgdr6dgCK9xNNqOCC35Aa9wAYvGse/qGPNMeGd3jJd4EYdWwmBhJkEvBvA22tZgBCuwDqO4jJltkpqKuzjYpn8KuRwmJQKywh4JA+M6zmZ8NjbF7MF7rBSeXBEuxlUGuRyKhG0QxPcLLdMK3UL135SiWg5jOKSEPcQ37MR0nMLtgqRDuCNUtiqM4ZAS9gWPMQ8vcawg4aAwDFYJD6QK/MYhNTz41Y4DeJeT8CT2Yr1Q6SqQ5JCqGMwQPsLncxIOYxfWCt++KtCSQ0pYDYvxQPgLSWEEu7FVeFlnRfvHuIowTWj1BnqwJOZ60kZ8IYdUK86PG+cNjAPCFLqC55l1KOOzT5ikPYn4vpi/scdgPD/RZnwhh1TFlsZjnrBazr0GeoX2eJq4d7WNHHnxhRxSws7FVRabhD+L0SriWw2PP4FlVca3GvcTHv+FTTT8BBTUfPip6CuaAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$\\displaystyle {\\gamma}_{2,1,2}$"
+      ],
+      "text/plain": [
+       "gamma[2, 1, 2]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABOUAAAAZCAYAAAB+QJr2AAAABHNCSVQICAgIfAhkiAAAC0BJREFUeJztnW3oJVUdxz//djGj1XYlojRqjQqVHtZaeiFsXDeESKhNWoII+UNUtPSiIhJ7gH9B+cIU3WCLXt0wotKwqAyk6L6xXB/oAdMtg1bJXFNLTXF1dbcXZ4a9c3cezsw59zzc+X7gMrt35jdnft//987vzLlz56xtbGwghBBCCCGEEEIIIYQIx0s61n8EuB14EngR2LH0IxJCCCGEEEIIIYQQIk82gGPAEeCnwJubNtzcspMLgO8DzwA3Ag8VOxRCCCGEEEIIIYQQQpzKDDgdc2PbB4CzgXfVbdg2KHcxsAZ8Cdjv9/iEEEIIIYQQQgghhFg5ZsUL4G5gJ7AFeHpxw7afr55VLO/zeGBCCCGEEEIIIYQQQoyBQ5gb3rbVrWwblNtULI81rL+sWHcQeH3DNl8FTgCf6DzM/JEe9UiXKtKjGWlTRXrUI12qSI96pEsV6VGPdKkiPeqRLlWkRzPSpor0qEe6VBmDHuWY2qa6lZsmk0lT4KR4fQ84XLP+LOCcYpvTgFsW1r8B+AHwB2AfRsRcmQI3Aw8Af2zYZkx69GFMukyRT1wYizZTun0C49GjL2PRZYp84sJYdJkin7gwJl2mqI8ylDHpMkU+cWEs2kxR7XFhLLpMkU9K9mCeLXc98MTiyrY75bYWy2cb1t8GfBAzEcTOmvX7MaLuA45bHmzOSI96pEsV6dGMtKkiPeqRLlWkRz3SpYr0qEe6VJEe9UiXKtKjGWlTRXrUI12qjEGPo8XyFXUrmwbl1oBdmFHIB1p2/hxwL3D+wvvvBy4FvgvcZXukCXMlJsebO7Ybix59GYsu8ok7Y9DG1icwDj2GMAZd5BN3xqCLfOLOWHRRH8WNsegin7gzBm1Ue9wZgy7yyUkOF8tJ3crFQbn3AtcAdwDvwCR/pKOBQ8AZwGuL/78MuA54DPjiwrb7gH9gRgrvxgz82fJu4OfAvzCDhR/qEeva/sOYPJ+02NZWj5j5+IrvQy4+cYlfRZ/4aL8vttq4+tc1tyuBO4GngEeLfb3FIq6PT8BOD19/JxdNh+oxlFDnFB95DWl/GT6BePn4jO9DLj4Z+hleVZ+Erj25+MQlfhl9lNg+SbXuxOpfzJPSNU+s8+M8IesOhOu7rVLt8eH7mNeBQ8jlnJLSNY/L8ZTE0PMGzM1u3wR+DHwd2F6urBuU+xzmtsF7gG9ZHNShYnnB3EGeC1wB/Hduuw9jfkP7DeBCzG2KvwJeZ9EGwMuBPwGfttx+Edf2bbHVI3Y+ofQoycUnrvG25OKTUHrMY6OND/+65jYBDgAXAbuBF4Bfc3Lmal/Y6OHj7+Sq6YQwepSEOqdMcMsrtdozIW4+q1p7JrjpmlrtmRDXJ6FrTy4+cY23JRefuLbfl1B9twmqO/PE7gsPIVTfbcLq1J4J7p/nXK4DS3I5p7jG25LLOWVI+w8BV2EmfNiLGWTcXq5c29jYWAw4E7gY+CHwOGYGjBdbGrgM+AnwWcwo4V8wD+G7iOpD+A4CfwY+Pvfe/cBNGMH7cAKTzE09Yny234atHvPEyCeUHiW5+MRnfBu5+MS1/SHYaOPbvz5y24L5JmgP5rh90dcrQ3Pxremy9CiJcU6B/nmlXHsgfD5jqD3g5v/Uag/E9X2I2pOjT3zEN5GjT4a035dQfbdFYuvaRCifzBO7L2xLqL7bIqtUe1w/zylfB5bkck7xHd9ELueUIe1fCvwC86XAJ4G/cXJG1tpnyj0F/AwjyDmc+rveReZHNK8HNnPqrBinAe8Ebl2IvRUj8rIJ2b6NHq645hPj75GDT0KSg09i0aVNqnmdgTmn/sfzfnP1yrL0KIl1TumTVw61J2Q+Y6o9y/b/UHLwSQxy9UlqdSe2T1KoO8sgtq5NhPCJK7HORzl4JSRD9Eg1F5/k6pOca88ysGl/d7HcwAw2Hptf2Tb7ajnBQ9dtgH/H3Em3FzMC+G3MiOY8rwQ2AY8svP8I8OqO/fvAtf3XAOfRMFvGAjZ6uOKaT9/4KebDsN7nIBfIwSeurJpP+jLF3SfQrU2qPrkOM9337R3b9fEJ5OuVJj2mhPEJhM2rDpf2Q/kkVD5946eMxycurKJP+jIl3z6Kq0/6xIfoo8T2SVv7U8L4ZBmE1DU1n7gS45oH8vCKCyFqT0if9GXKuH2S2jVPbK/YtL+tWB6uW9k2KHfMYhuA5zEPztwK/Bv4Ssu2i6OcazXvLZOh7V8F3IeZqreLPnq44qqnbXzpgRd67HuRnHwylFX1iS0+fAL22qTkk6sxDw3dS/vP/aGfTyBPr7TpEdonECavNoa0H8InIfPpGz9GnwxhlX1iS659FFef9I1fdh8ltk+62g/tE1+E1jVVn7gS8poH8vLKEJZde2L5xJYx+yS1a57YXrFtv9UzbQNufQpieavhFcATNesfwxzk4jcSr+LUby6WQej2u/RwxTWfvvFvBf4H/LLfYZ5C6j4JTeo+6Ysvn0C7Nqn55BrgcuA9mG94lkFOXunSI5RPIGxedaRce2Lk0yd+TD4JTeo+6UuOfRRXn6RWd2L7xKb9UD7xSWxdbVi2T1yJdc0D6XslNLZ65JDLWH2yCrXHJ0Parx1jaxuUe65YbmvZpmQbcBy4sWH985jppy9ZeP8S4HcW+3fFtf11zDcqU8v2uvRwxTWfPvFbgbcB36E668kQUveJK+uslk/64NMn0K5NSj7ZD3wUMznOvZYx6/TzCeTjlS49QvoEwuXVhEv76yzPJzHy6RM/Np+4sM7q+aQPOfZRXH0yNH6d5fRRYvvEpv2QPvFFLF3XScsnrsS65oH0veLCOsupPbF80oex+iS1a57YXunbfjmmdrRu5eaWwPuL5ceAuzDTuB6v2W4NeDvwV+CZlv1dC9wA3MHJWSfOxhjahi3AG+f+vx3YgXmg3oMW8a7t22KrR+x8bON3YX7KfK3lfpvIxSeu8bbk4hPb9n35BOy08fF5dtX2AOZkvKeIKb+Ffbp4+cJGDx++ddXURo/QPoEwebWRWu2JnY9N/Bh9klrtie2T0LUnF5+kVHd8HE8oPUP7JHb/YtXqTqi+cOja4+O8H1tbW2z08HF+C3EdGKOPEvucsmq1J6SeL8XkNMFMqPpo3Q7b7pS7BbgH85C9BzG3/u6o2e5NmMS6HsL3I+AzwJcxD8LbBbyPkxNKgBlNPYERZpGdRRtlO1cX//6aZbxN+z6w1SNEPq7xYKb1PR040pFPF7n4xCbeB7n4xFYPXz4BO21c84Lu3LriP4WZbec3wMNzr8+3HPcQbPRw9Ql0a9oVb6NHaJ+Au1ds8mqLT632hMjHNX6MPkmt9sT2Sejak4tPUqo7tsezzvJ8YqtHaJ+41mTVnSqhrgFD1x4ffbcubbviU6o9rj4B9769jR4x+iixzymrVntC6AlmptWjwEHgTMxAbt1Nbq13yj1bHPBu4HyMQHXmu7BY2syMcaB4NXEu5va/f9asm2FGT9toi7dp3we2esxYfj4p6FGSi09s4n2Qi09s2veNrTau/p/RnltXfChdbPSY4e4TaNc0FT1KQp1TbPJK4Vxrq0eIfFLQoyQXn8ws9+FKLj6ZWR6DL3LxSUp1B+L7JNW6M8OtJqvuVJlZ7CMFPeYJ1Xdzjbc5Bh/Y6OHD97OO/aSiR0ku55RVqz0zi3340GOGmdjhceD3mC8Falnb2Niw3GcQ7gS+APw2UnxqSI96pEsV6VGPdKkiPZqRNlWkRz3SpYr0qEe6VJEe9UiXKtKjHulSRXo0I22qZKVHaoNyQgghhBBCCCGEEEKsPG3PlBNCCCGEEEIIIYQQQiwBDcoJIYQQQgghhBBCCBEYDcoJIYQQQgghhBBCCBGY/wOIWwHh0vybRgAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$\\displaystyle \\left\\{ {\\gamma}_{0,1,0} : {\\gamma}_{1,0,0}, \\  {\\gamma}_{0,1,1} : {\\gamma}_{1,0,1}, \\  {\\gamma}_{0,1,2} : {\\gamma}_{1,0,2}, \\  {\\gamma}_{0,2,0} : {\\gamma}_{2,0,0}, \\  {\\gamma}_{0,2,1} : {\\gamma}_{2,0,1}, \\  {\\gamma}_{0,2,2} : {\\gamma}_{2,0,2}, \\  {\\gamma}_{1,2,0} : {\\gamma}_{2,1,0}, \\  {\\gamma}_{1,2,1} : {\\gamma}_{2,1,1}, \\  {\\gamma}_{1,2,2} : {\\gamma}_{2,1,2}\\right\\}$"
+      ],
+      "text/plain": [
+       "{gamma[0, 1, 0]: gamma[1, 0, 0], gamma[0, 1, 1]: gamma[1, 0, 1], gamma[0, 1, 2\n",
+       "]: gamma[1, 0, 2], gamma[0, 2, 0]: gamma[2, 0, 0], gamma[0, 2, 1]: gamma[2, 0,\n",
+       " 1], gamma[0, 2, 2]: gamma[2, 0, 2], gamma[1, 2, 0]: gamma[2, 1, 0], gamma[1, \n",
+       "2, 1]: gamma[2, 1, 1], gamma[1, 2, 2]: gamma[2, 1, 2]}"
+      ]
+     },
+     "execution_count": 125,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Concrete values of N_ee and N_en for all the following\n",
+    "NN_ee = 2\n",
+    "NN_en = 2\n",
+    "ftmp = f1\n",
+    "sym_subs = {}\n",
+    "display(ftmp)\n",
+    "for i1 in range(NN_en+1):\n",
+    "    for i2 in range(i1):\n",
+    "        for i3 in range(NN_ee+1):\n",
+    "            print(i1,i2,i3)\n",
+    "            display (gamma[i2,i1,i3], gamma[i1,i2,i3])\n",
+    "            #ftmp = ftmp.subs(gamma[i2,i1,i3], gamma[i1,i2,i3])\n",
+    "            sym_subs[gamma[i2,i1,i3]] = gamma[i1,i2,i3]\n",
+    "ftmp = f.subs(N_en,NN_en).subs(N_ee,NN_ee).doit().subs(sym_subs)\n",
+    "sym_subs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 126,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAADFkAAAAfCAYAAACGEPMZAAAABHNCSVQICAgIfAhkiAAAHEhJREFUeJztnXusbUddxz+3POulUBGVlzxUCpSGe0trFZB6KhQVEyxYUk2g2REjQgwQBExjSW7BIFoqpbaNAuqhBKU8IgSUiDxMSytQKkUepVjSIwJNeRRLKJSC1D9mr9x11tlr71mzZq2Z38z3k5zs3nXOzJrOd37fPb/Za/bsO3ToEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEELVzROoGFMgB4M3Al4DbgBuANwGPStmoggnt76Fj/yzgKuBbwNeAdwPHDawj97rEcKRl3Uj/csip/3NqS61IgzqR7vaJpaHGQnqkgT2kmT2Uy9SNNKsD6Vwn0l0IIcKQfwohckC5ejmo/+0hzcpAOgohckc+JUS+9D5Prk0WcTkTuBr4HnAGcMzyGsDzUzWqYEL7+xjgmQPvtQVcDDwO+GXgB8D7gXsPrCfnusRwtpCWNbOF9C+FLfLp/5zaUitbSIMa2UK6W2eLOBrGqkeEs4U0sMYW0swaWyiXqZktpFkNbCGda2QL6S6EECFsIf8UQqRnC+XqpbCF+t8aW0izEthCOgoh8mYL+ZQQuXIAOGXVL/YdOnRo1fVLgF8FHgrcOlmzbHEC8HHgd4G/WfH7xwGXAS8BXrPi9/cGbl5xXX29mqn6+yjgH4DTcSdfhHIP4BbgNNyuwjHkWpcYjrSsG+lfDjn1f05tqRVpUCfS3T6xNNRYSI80sIc0s4dymbqRZnUgnetEugshRBjyTyFEDihXLwf1vz2kWRlIRyFE7sinhMiLC4ALgc+3L646yeJE3Lf8v4ppHvr/IHAH8IQJ6p6Sq4F3An+CM7gu5wNXsvqBf1j9wL/6up8p+hvgvGXZMRsswG3WOGLNfUqoSwxHWtaN9C+HnPo/p7bUijSoE+lun1gaaiykRxrYQ5rZQ7lM3UizOpDOdSLdhRAiDPmnECIHlKuXg/rfHtKsDKSjECJ35FNC5MUrgNfT2Vex6iSL9wEnAfcDvhu5EfuAb+IM4l7AtyPXPzUnAR8F/hh4Zev6I4Brgd8CLh1Qn/p6PbH7+wTgjcBxEdp2KXAMbqPM/xValxiOtKwb6V8OOfV/Tm2pFWlQJ9LdPrE01FhIjzSwhzSzh3KZupFmdSCd60S6CyFEGPJPIUQOKFcvB/W/PaRZGUhHIUTuyKeEyI+/Bi4D3txc6J5kcQzwJOCtxH/oH+BhuAf+ryPOQ/8L3EkNWxHq8uFjwOeA5wB3al0/uHy9ekBd6uvNxOxvgLOBSyK061zgZOAZjH+Dy7WuUlgw37iVlvmxQPqXwgKbWpbUlpxYUOd4qJ0F0t06C+xpqLGwmgX2tKydBdIsNQvmX1PxRbnM9CyoQ//aWSCdrbEgX81iIN1Xs6Bs3WtngfS1woJ8tZJ/rmZBvpoJ6TMXC2yur8jX9rLAppa1s2Ae3aTZahbYeq+RjntZYEvD2lkgvVKwQHOE1CzQ2J+DBernPt4IvBy4S3Ohu8nid3AnIAw5HWAIJyxfhz4cPxWn4AbLubhTE96FO37nDuBRPWXeAjwIt0Gi4cjl65DNDOrrzX0N8fr7gcBTgbeNbN95wJnAE4HrJ65rSJ+tq+vpwPdxp4I8uKfN5yzr/b2e39eK9XEB0n8MiuVySBHLU7dF4yGcVH48pi0N0j2cXHSXhuHMraF8eDo0L7aH4iY9Q8d7jrms9A/Hgv4gjccQMsdUbKZnqtiMcU+tL01HzrqD9B3DlF7ch/QKJ9X8SJqFM3WMSZtwtL4yH/rcsRyUd9tDc4H0zPUZO8j7pkL5rR2Uq6ZDa3dpUW4zD6X325XA3XD/n8DeTRZPwu2M+shEDThx+frxieofymOWr8cBlwM/xB338fe4ExRWccXy9dTWtU8vX0/uKfMjK66przf3NcTr7zOAW4AbRrTvAuCZOEP+7Jo2x6rLt8821XUT8K+4N4+Xrvj9Ty+vXwW8Yc3/V41YHhcN0j8cxXI5zB3Lc7RF4yGcVH4cow7pHk4uukvDcObUUD48LZoX20Nxk56h4z3HXFb6h5O7/g3SOJyQOaZiMz1TxGaMe2p9aVpy1b1B+oYzlRevQ3qFk2p+JM3CmTrGpE04Wl+ZD33uWA7Ku+2huUB65viMHeR9U6L81g7KVdOhtbu0KLeZhxr67T+A327+cefWL/YDB4FrgVsnunmuD/7/IvBL+G14uGr5enLn2j8DF+Ie8L8CtxPnBNxunLOBf2/9vfraf3NJjP4Gt6nlEyPadzHuDe403A63+y6vf5u9J2rEqsunz3zqugJ4GvANDo+LNhcAdwWeh3tzEYexOi7aSP9wFMvlMGcsz9UWjYdwUvlxSFu6SPdwctFdGoYzl4by4enRvNgeipv0DB3vOeay0j+cnPVvI43DCZljKjbTEzs2Y9xT60vTk6PubaRvOFN48SakVzip5kfSLJypY0zahKP1lfnQ547loLzbHpoLpGfqz9hB3jc1ym/toFw1HVq7S4tym3mood+uAV6AO8Tih+2TLB4A3Am4caIbHwEcjzu94ZqJ7jGUJrBegP8byi3AbcCDOtefDrwaeBHu/+8q3I6cK9j7cL/62p8Y/Q3w8xw+ASOkfc8FjgI+gNOt+XnxhHX59JlvXd/D7X58ZOf6U4FfB15HPhtycsLquOgi/cNQLJfDnLE8Z1s0HsJI6cdD27IK6R5GTrpLwzDm0lA+PD2aF9tDcZOeoeM9x1wWpH8oOevfRRqHEfKepthMT+zYjHFPrS9NT466d5G+YUzhxT5IrzBSzo+kWRhzxJi0CUPrK/Ohzx3LQXm3PTQXSM/Un7GDvG9qlN/aQblqOrR2lxblNvNRer99GrgncCzAvkOHDjW/eCxwJfBW4IwVBXeABw+40ZtxO68aHoE7ueEzuCNZhjL0/m8EFmt+vx/4FvB14H6s3jVzEfCTwOmd619eXr/znhJ+bOprGNffFvv6T3EnUTx5xe/G9vd9gK8B5wCHAtvnS6y6Yrap4RLgWcBPAV8CjsSNkaOAY4BvRrhHSnaYf9z6Mue46Isl6b+bufRXLA9nhzy19K2rO3dox6TGw3B2yHM8+NbTHg9df5an97ODXd3XeUAbabibnDQcirTcTW5aropBababOedSDdJgN7HXr3LMZdtI/91Y179Gn4W4OofkForN4exgIzbH5pBDKF1zsKH7phxSXtzPDvl7sdYIHDvkH4tDkWa7meIzeflfPzvM6399z0uU3tc75Lm+Ik8bzg55aulbl7zOjxhzvSGUrsEO6ecC+ox9HDvkpaFvHfI8P2Lnt8pV/Zj787TS+x/SjP0afWaHuGO9oeR+OxV4H+7Ejne2H1r/7vL17j0Fv4A7UcCXr3T+3RwNErpD5Xzg6M61g8Bv4ITd6fxu0wkOB3AnPvwT/UF1NvD9FdeP5HB/hbCpr2Fcf1vs6z/DnbyxirH9/YDl67d6fu/TPl9i1RWzTQ2fW74eizO2s4CHAs9mt6mdhTsp5OG4XWcfWV5bdxJIm1TlU4xbX+YcF32xNJf+JwMvwU1I7gc8A3i7Z9kx989Vf8uxDO7orpfgtPwM8ELgcs+ypWnpW1d37tCOScvjIZU35DoefOtpj4euP0/t6an9fEwdlnVf5wFtrHh5jRoOxYoPQ9hYsK7lqhi0Mi+GsjRrY8UDQ8unXr/KMZdtY2UeYymfSan/GJ8dq1Oq9QeIq3NIbpHSm1O9vzWUHptjc8ghWJoTWcpLhuq+KYcs3YvHlLfgxTHXCGLEEtSzRpDL+2YOHmoxp/EtY9n/IDwe5/a/vuclrMwfQ8vnur5i2dOgnlzAl9y9DtJoBmnmekPw1QDSeFiDpbgp9TN2qHMODvbyW0ijFaTPb8d+ng1pvc5SnAzBik+NKZ9i7Fv2mdDyscd6gxWPCCnfPGd+f9h9MsBXl68/1lPwiQMatYrmwf+rA8ufv+LaAif2NvBvA+trjof56Jq/WbWb5gjcoLth4P3abOprGNffFvv6f3uux+jv/cvXW3p+79O+i1j9LR0x6lq1Q86nnr6yfbSN7QvAS3FvrH/X+bst4GLgKmAf8HLg/ctyN3vcJ1X5FOM2x3HRF0tz6b8f+OSy3nd4/H2X0Pvnqr9vLPvo3zCXlmcAr8VNND6MO7buvcvyX/QoH3r/XLX0ras7d2jHpE/5Ib4Odrw91BtyHQ++sd0eD11/ntrTt0jr52PqsKz7Og9oY8XLa9SwVB8OHQuWtYTVMWhlXlyaZm2seKAlDdrvPyE5SJ/3pfLNLdLPY0LbYEF/3/wzdL7qG+NjdUq1/gBxdQ7JLWLq3DCXbjWtNYR489gcMse14tpyy6G6b8ohS/fiMeUteHHMNYIYsVTTGkGIB5fooVZzGt8ylv1vTDzO7X+rnpcAO/NHS3FQ+jMENeUCpeTdqTSDNHM9n7WyBl8NUnlYwxZ24mbsZ+xQpvdZnYODvfw2lVaQPr8d+3l2aq+zFCcl+pSl3AZs+0wuuU2DFY8IKd88Z74fdm+yuBH4Gm5X0xScsHwNPV0hNk1g9bXngcD/AI8ArmtdfzjOkHx37KxCfb2bo3Fv3gdxRtQmRn/vW77eEdg+6P+Wjhh1rdoh51NPX9k+2sb2JFz8P4+9/fIrnX8/C2ccjwfe7XGf1OVjYXFcrIulufR/7/InlNL0941l3281g/m0fBFuMvX65b+fD/wabrJxlkf50rT0qas7d+jGpE9bhvg62PH2sd4Qizljuz0ebmKvP0/t6TloVpvumzygjRUvr01DKNeHx46FWMypZV8MWpkXl6ZZGyseaEWD7vtPSA7S532pfDN1/MVoQyym0N83/wydr/rG+Fidalp/mFLnhrl0q2WtIUSzsTkk5LlWXFNuOVR3nxyydC+2oi1Mo2+Dj14x+qqWNYLQ+XGJHmo1p/EpY93/LGvTYGX+aKWvofxnCGrJBaCcvLsmzcBvrazBV4PUHmZFgxifsUOZ3md1Dm4xv61FK9i8BtVgxess9X2JPmVpvm3dZ3Lp6wYrHhFSvjkNZR/s3mRxB3AZ8JvAzwLXezTAlyOA43EmMeZh+Zg8Brgd+FTP7w8C3wH+q3P9F5avHxpxb/X1bg7ikpVrV/wuRn/funy9Z8/vN7UP+r+lI0Zdq3bI+dTTV7aP63Hj4hm4N40LgU94lDsKN658djfmWD4Ui+NiXSyl0n8s1vX3jWXfbzWDebS8K27D3qs7198HPM6j/Nj7x2TOWO7OHbox6dOWIb4Odr09FXPGdns8nMxef57b061qFoO5dN/kAW2senkq5ozdEn04p7Ewtw+vikEL8+ISNWtjwQMtadB9/wnJQfq8LxffzGEek2s+E6K/b/4ZOl8NjfHU5KoxTKtzwxy61bTWEKLZ2BwSbKwVWya27j45ZG1enIopvHiONYIh5DS/HctU8+PSPDQnzUM+ky/Z/6xr02DBuyz1NZT9DEFNuQCUkXfXphn4rZU1+GiQo4flqkGMz9ihDu9LRen5bU1aweY1qAarXpcKi2t3JemX4rPjIZTU1w0WPCK0/L2Wr7eCC6g2zTEm3R1OY3kk7uiM24C/BN6w4udVke+5jrvhdtB8ChdcqzgA/CeHd6U0PBk3ON41sg3q68McxJnXqt/H6O+blq+rNln4tO+BuI0xm04eCanr6OW/Dwysp6/sOm4HbliW+yrwMs9y5+M27HzE8+9zKx+C1XGxLpZS6T8Wy/r7xrKP/m3m0PI+wJ047J8NNwH39bzfmPvHYu5Y7s4d2jHpU36or4Ndb0/B3LHdHg9df07h6RY1i8Gcuq/zgC5WvTwFc2pYqg/nMhbm9uG+GLQwLy5Nsy4WPNCSBu33n5AcpM/7cvLNHOYxueYzQ/X3zT/HzFdDYzw1uWoM0+ncZg7dalprCPHmsTmklbViq0yh+6YcskYvTsFUXjzHGsEQcpnfjmUqDy7RQ3PRPCReSvc/y9q0seBdlvq69GcIasoFSsm7a9IM/NbK2vhokKOH5arB2M/YoR7vS0EN+W1NWsH6Nag2Vr0uBVbX7krRL9Vnx0Mopa/bWPCI0PLNc+Y3wu6TLMA9+H8TcCZwkUcjfDlh+bofeHbP3/xLxPtt4jjgLsDVa/7mIHtPgrgXcBrwHtyxSWNQXx9mVV9DvP6+Eber6OgR7ev7lo6xdR1k7w45n3r6ym7ic7jTU/4Iv92R5+J2rT4B/+OqciofitVx0RdLDXPrPxbr+g+JZd9vNWuYS8vuEV77VlzzwbqWQ+q6puffvuWH+jrY8/ZUpIjta1b895C2xPJ0q5rFYE7d13nAKqx5eSrm1rBkH049FlL6cBcr8+JSNFuFFQ+0osGQOWdTZtM3VeXimznMY3LPZ4bmHD7559j56tAYT03OGsN0OneZS7da1hpCvHlsDpn7WrFlpvLkdTlkbV6ciim9eMo1glBSz2/HMqUHl+qhqTUPiZda/M+iNl2seJeVvq7hGYJacoGS8u4aNAP/b3Vv46tBLh6WswZjP2NvypTufamoKb+tQStYvwbVxZrXpcL62p11/VJ8dhyK9b7uYsUjhpZvTrK4HvZusrgdeC3wSuB44h17csnyJzbby5+hXI3rqHUcAM7rXDsTuPuK6yGorw9zAHjTiusx+/sq3CkfXXzb1/ctHWPrOsjeHXI+9fSV3cSPLu/9No+/PQ94JnAKS8MYSOryMP24zW1c9MVSw5z6j6UE/X1jeci3mjVMreXXcRPu7q7Nn2Dv7s4p7t9lGzuxfF7n301M+pQP8XWw5e0x2MZObJ/X+u+2P8/p6TloFoNt8td9nQeswpKXx2Cb/DUs1Ydjj4Vt8teyqasvBnOfF5em2Spy90BrGjTvPyE5SJ/35eCbOcxjLOQzQ/T3zT/HzleHxHhqYo2zbYbrHJJbxNS5y9S61bbWEOLNY3LI3NeKc2GbfHTflEPW5MWx2CYvL55qjSCE2tYIhnpwiR5qNacZUsaq/00Rj9tM43+rnpdok7t3WYuDkp8hqC0XKCHvzk0zmH6u5/Ot7m02aZCTh1mImzGfsUP53heDbdJoOKSOEjwvFtvMk9+OzVVz8roYbDNdnJToU5ZyG7DtM7nkNl1y94jQ8sfivtT/swBHrPiD1wBfBF7u0YhS2Q/8DLt3Lh0JnIU7geLySPdRX7tdZMcCn+xcj93fH8JtZglh067NMXWNqXto2X24N4vrcCawjgs4/Mb72YC2pS4/B7mNi75YaphT/7Gkvr8PKfWfQ8vbcZPQUzvXTwWuHFBPTVp25w6bYjJWWyx5uwWmGA8hYyGWp9egWQxi6D7UAyx5uQVixW6pPmxpLMTScl0MWpgXl66ZBQ+0osGq9SsfhnxTlW89vliax+TQhnWE6B9rXSqWz6Ymd41hPp3n0K2WtYYQzcbmkJD3WnENDNU9xjpSKV5sgan1teTBuRNjfuyDBQ+1onmIZtb9rxRtLHiXlb6G8p8hqCUXgHLy7po0g+FrZT4a5OJhuWsQIzeCsr0vd0rIb2vRCoatQVnyOguU6FOW9LPuMzn2tQWPCC1/PHAZ8APYe5IFwG3As3BBt598FyCm5NHL10+1rj0EeB1xdvA0qK+ded2VvW8iDyFuf78FOAe4P/CVgWU3fUvHmLo27QjdVNeQsg8D7sHmU1Muxr3xngbczOGdXN9e/mwidfm5yG1c9MVSw1z63wN3DFTDQ3ATxZtxm8o2If036z+Xln+xbMfHgCuA5+A89K88ysa4/1zE0rI7d9gUk31tGRr7Vrx9rDfMxRTjIWQsxPD0HDSrSfehHmDFy2vSsKmnVB8eOxbmIpaW62LQyry4ZM2seKAFDVatX/kw5JuqNtUzhW+mjr8YbZiDEP1jrUvF8NmxOtWy/jCXznPpVsNaQ4hmY3NIyHetuJbccqjuMdaRSvBiC9rC9Pr66BWjr2pYIxgzPy7RQ0vNaUrwvxK0sTJ/tNDXUMczBDXkAlBW3l2LZjB8rcxXg9QeZkGDGLkRlOt9FufgVvPbGrSCYWtQVrzOSt+X6lNW5tsl+ExufW3FI0LKH4971hxYfZIFuF0Y51DnQ//gTO3zwHda164FDgE7ke9Ve18fBL4MfKNzPXZ/fx74IPD0geVCv/XGp67QHdihZZuTPDYZ23OBo4APADe2fl7c+psFcAfuzSJF+dTkOC76YqlhLv1PXN6juc+5y/9un9izrrz036z/XFpeCrwQOHvZvicATwH+27N8bVp25w6bYrJLaOzHGg8L+rX0Kb+pDh9vSM1U42HoWMCjjI/uqf3ct47UxNJ9qAfMFbubvHxT+Zo0TO3DMO0c2+d9PTUxfXhdDFqZF5esWS4euKkOCxqsWr/aRIxvS2dEWSvzGAv5zFD9Y65LxfDZsTrVsP4A8+kcS7cF03qzBd1CvHlsDpnzWnEtueVQ3ceuI20qY8WLLWgL0+vro1eMWKphjSDEg0v20FJzmhL8rwRt5urrGnL7Wp4hqCEXKC3vrkEzCFsr89VgDg9bV96CBjFyo5K9z+Ic3Gp+W4NWMGwNyorXWej7kn3KwnwbyvCZ3PraikcM7bcDwD2BtzcX9h06dKjnb4WYhQtxO4OGbn4I4RTgz4GfG1DmscCHcW9GQxb4fOo6gAvc+zBscsnIsjE4Bzh92Y4fJCifmhzHxZyxJP3z0z8UaRlPyy5DY9K6r8eqIyVTjYcQf57L02v3AMhL9xCkYTwNU/swSM+Y8agYnIcp51I+aP4SRlu3h6F1iVq1H5t/ymfzxfo6Q6w6LBMSX/Jk+2jtoGykVd7IQ+2hmCqP2vtazxDEK58a5d02ibVWFoo02I1yYvsov7WDnjObD/lUeuQzeZNTv70GdzrJK5oLfSdZCDE1R+J2d50OvHeme34IdzLGSQPKhHyDim9dIbt3G8aUjcFTgD8g3JTGlk9NTuMiRSxJ/3z0H4u0jKdlQ2hMWvf1WHWkJPZ4CBkLc3t67R4Aeeg+BmkYT8PUPgzSM4aWisF5mWIuNQTNX8IY8k1V60jtm7XHXwgx8k/5bP5YX2eIVYdFxsSXPNkuWjsoG2llA3moHRRT5VJ7X+sZgnjlU6O82yax1spCkQYO5cR1aijPS4OeM5sf+VQ65DM2yKXfjgIeD7y6fVEnWYhUnA38PvBu4PnA92e6748Dfws8jfRmNGaH3Jy7ScW8DNU2VSyJaVBs2yc0JqV9eYSMBXm6faShXeTDZaAYFGIYWpeomxAN5bP2UKzaYUx8SWe7aO2gbKSVDeShdlBMiVpQrl4OyrvtoRhKh3Ji+yi/tYP6fX7kU+nQeBdDOB94B3B5+6I2WYgaORE4Frgk0f2PBB4FvAd4GfD6mcqKvJG2dSP960XaCyFEWuTDQoga0bpE3UjDOpDOdSCdhRAiHHmoECI3lKuXg/SwhzSziXQTQuSOfEoIOzwaOAl4Q/cXR8zfFiGS83Hg0oT3/0PgncA/AtszlhV5I23rRvrXi7QXQoi0yIeFEDWidYm6kYZ1IJ3rQDoLIUQ48lAhRG4oVy8H6WEPaWYT6SaEyB35lBB2uI4VGyxAJ1kIIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIAOslCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghhBAC0CYLIYQQQgghhBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIQJsshBBCCCGEEEIIIYQQQgghhBBCCCGEEEIIIYQQQgghAPh/xKguBqidJ4kAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$\\displaystyle \\left(- L + r_{i}\\right)^{C} \\left(- L + r_{j}\\right)^{C} \\left(r_{i}^{2} r_{ij}^{2} r_{j}^{2} {\\gamma}_{2,2,2} + r_{i}^{2} r_{ij}^{2} r_{j} {\\gamma}_{2,1,2} + r_{i}^{2} r_{ij}^{2} {\\gamma}_{2,0,2} + r_{i}^{2} r_{ij} r_{j}^{2} {\\gamma}_{2,2,1} + r_{i}^{2} r_{ij} r_{j} {\\gamma}_{2,1,1} + r_{i}^{2} r_{ij} {\\gamma}_{2,0,1} + r_{i}^{2} r_{j}^{2} {\\gamma}_{2,2,0} + r_{i}^{2} r_{j} {\\gamma}_{2,1,0} + r_{i}^{2} {\\gamma}_{2,0,0} + r_{i} r_{ij}^{2} r_{j}^{2} {\\gamma}_{2,1,2} + r_{i} r_{ij}^{2} r_{j} {\\gamma}_{1,1,2} + r_{i} r_{ij}^{2} {\\gamma}_{1,0,2} + r_{i} r_{ij} r_{j}^{2} {\\gamma}_{2,1,1} + r_{i} r_{ij} r_{j} {\\gamma}_{1,1,1} + r_{i} r_{ij} {\\gamma}_{1,0,1} + r_{i} r_{j}^{2} {\\gamma}_{2,1,0} + r_{i} r_{j} {\\gamma}_{1,1,0} + r_{i} {\\gamma}_{1,0,0} + r_{ij}^{2} r_{j}^{2} {\\gamma}_{2,0,2} + r_{ij}^{2} r_{j} {\\gamma}_{1,0,2} + r_{ij}^{2} {\\gamma}_{0,0,2} + r_{ij} r_{j}^{2} {\\gamma}_{2,0,1} + r_{ij} r_{j} {\\gamma}_{1,0,1} + r_{ij} {\\gamma}_{0,0,1} + r_{j}^{2} {\\gamma}_{2,0,0} + r_{j} {\\gamma}_{1,0,0} + {\\gamma}_{0,0,0}\\right)$"
+      ],
+      "text/plain": [
+       "         C           C ⎛  2     2    2                    2     2             \n",
+       "(-L + rᵢ) ⋅(-L + r_j) ⋅⎝rᵢ ⋅r_ij ⋅r_j ⋅gamma[2, 2, 2] + rᵢ ⋅r_ij ⋅r_j⋅gamma[2,\n",
+       "\n",
+       "           2     2                    2         2                    2        \n",
+       " 1, 2] + rᵢ ⋅r_ij ⋅gamma[2, 0, 2] + rᵢ ⋅r_ij⋅r_j ⋅gamma[2, 2, 1] + rᵢ ⋅r_ij⋅r_\n",
+       "\n",
+       "                     2                         2    2                    2    \n",
+       "j⋅gamma[2, 1, 1] + rᵢ ⋅r_ij⋅gamma[2, 0, 1] + rᵢ ⋅r_j ⋅gamma[2, 2, 0] + rᵢ ⋅r_j\n",
+       "\n",
+       "                    2                         2    2                         2\n",
+       "⋅gamma[2, 1, 0] + rᵢ ⋅gamma[2, 0, 0] + rᵢ⋅r_ij ⋅r_j ⋅gamma[2, 1, 2] + rᵢ⋅r_ij \n",
+       "\n",
+       "                             2                             2                  \n",
+       "⋅r_j⋅gamma[1, 1, 2] + rᵢ⋅r_ij ⋅gamma[1, 0, 2] + rᵢ⋅r_ij⋅r_j ⋅gamma[2, 1, 1] + \n",
+       "\n",
+       "                                                            2                 \n",
+       "rᵢ⋅r_ij⋅r_j⋅gamma[1, 1, 1] + rᵢ⋅r_ij⋅gamma[1, 0, 1] + rᵢ⋅r_j ⋅gamma[2, 1, 0] +\n",
+       "\n",
+       "                                                 2    2                      2\n",
+       " rᵢ⋅r_j⋅gamma[1, 1, 0] + rᵢ⋅gamma[1, 0, 0] + r_ij ⋅r_j ⋅gamma[2, 0, 2] + r_ij \n",
+       "\n",
+       "                          2                          2                        \n",
+       "⋅r_j⋅gamma[1, 0, 2] + r_ij ⋅gamma[0, 0, 2] + r_ij⋅r_j ⋅gamma[2, 0, 1] + r_ij⋅r\n",
+       "\n",
+       "                                             2                                \n",
+       "_j⋅gamma[1, 0, 1] + r_ij⋅gamma[0, 0, 1] + r_j ⋅gamma[2, 0, 0] + r_j⋅gamma[1, 0\n",
+       "\n",
+       "                     ⎞\n",
+       ", 0] + gamma[0, 0, 0]⎠"
+      ]
+     },
+     "execution_count": 126,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Three body Jastrow with symmetry constraints\n",
+    "ftmp_sym = simplify(expand(ftmp))\n",
+    "ftmp_sym"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 127,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABIoAAAAZCAYAAABerMULAAAABHNCSVQICAgIfAhkiAAACf1JREFUeJztnW2oZVUZx3+3GcxoNEciQqPGqEDpZayhD8LEcUKIhDJJgogIoqKhDxWR9AanoPpgik4wRZ9OGFFpUFgGUnS/VI4vpGE2ZdAkWWNqqSmOjs70Ye3DHPc9e5+1z3rf6/+Dy5k5ez9r7d96nrv2ZbHPOhvT6RQhhBBCCCGEEEIIIV6w4vj7gVuBx4DngN3Br0gIIYQQQgghhBBC+GYKHAeOAj8BXrfspO09DVwAfA94ErgBeKBpTAghhBBCCCGEEEKUxSZwOuYhoHcD5wBvbZ/Ut1B0MbABfAE44P/6hBBCCCGEEEIIIUQkNpsfgDuBPcAO4InFk/o+enZ28/onzxcmhBBCCCGEEEIIIdJxGPNw0M72gb6Fom3N6/GO45c3xw4Br+o458vASeCjVpdZFvKv179md5C//Ov1r9kd5F+zf83uIH/51+tfszvIv2b/Wtznaz3b2ge2TSaTrqBJ8/Nd4MiS42cD5zbnnAbc3Dr+auD7wO+B/ZhBHBPyr9e/ZneQv/zr9a/ZHeRfs3/N7iB/+dfrX7M7yL9m/1rcL8PsVXQd8Ojigb4nis5qXp/qOP4b4D2Yza73LDl+ADOo+4ETAy62FORfr3/N7iB/+dfrX7M7yL9m/5rdQf7yr9e/ZneQf83+tbgfa15f0j7QtVC0AezFrIz9vafhp4F7gfNb778LuBT4DnDHkCstDPnX61+zO8hf/vX61+wO8q/Zv2Z3kL/86/Wv2R3kX7N/De5HmtdJ+0B7oegdwNXAbcCbMfJHVzR+GDgDeEXz/xcB1wIPA59vnbsf+Btm5epOzGLUEFLHL6MU/7cBNwH/xCwAvndg313Y+vsYe5c2PgfcDjwOPIQZi9evcQ2L2Lr7GPuSaz+1f+raT+0fovbBzt/V3VfufNd/rNynju+iFP+Ute+r/9zm/lLcU9d+av/Saz/1fbMLG/8c3EPUfym5L732U88dXZTiX3Ltp4q/HvNg0DeAHwFfBXbB8oWiT2Mer7oH+KZF44eb1wsWLvI84ErgvwvnvQ/z2bevARdiHuf6BfBKiz5yiO+iFP8XA3cDn7A83xYbfx9j79rGBDgIXATsA54Ffsmpb/dbB9vcu4596trpohT/lLXvo/8cax/s/F3dfeQuRP3Hyn3q+C5K8Z+QrvZ99J/j3F+Ke+ran5DW37X/LmL5p75vdmHjPyGtu6822pSSe9f+u4jl7xqf+m/+CWn9S679VPEPAF/HbGp9BWbxaxfAxnQ6bZ98JnAx8APgEcwu38/1NH458GPgU5iVqz9iNnW6iOdv6nQI+APwkYX37gNuxAz4KlLHd1GK/yInMYVw48C4Zdj4+7h23/nbATyG2cDrpjXiwT73i6wz9jnVziKl+Lv230WJ/uCn9mG4v+vYrxsfov5j5T6n+EVK9Id0tb9u/znO/aW4L5K69iGt/zr9dxHLf5Ec7ptz1vGP7R6iDSgn9z77XySF/zrxOdU+xPdfpOTajxl/KfAzzKLix4C/0HwT2rI9ih4HfooZkHPZ+pm8NourbNcB29m68/dpwFuAW1qxt2AGeRWp4/sowT8kq/x9XHsI/zMw9f+fNePBLveu5Fw7JfiHpFR/H7UPcfxdCVU/JbiHpFT/1LU/pP9c5/4S3ENSqn9Jte9Kbn/3xHQPSQm5D9l/Kv/Uc8ecEvxDUaq7bfy+5nWKWQQ7Pj/Q961n802sVz2u9FfME0dXYFakvoVZZVvkpcA24MHW+w8CL1/Rfor4GSb5H7JouwT/Icywd4fV/j6uPYT/tcBdwK2t92f4zb0rpde+KzFrH+rw91H7EMfflSHjNyOv3Mdmxvj9U9d+V//LiDn3zwif+5juQ5kxfv++/mfk5e9KqNqH9fxjug9lxrhyP7T/Gfn7h5o7ZuR33wsR38WMceXeJX5n83qkfWB7T9B8NalvMQngGcyGWa8B/g18qefc9srbxpL3+ogVP3d+1qLNkvxtGOIO9v4+rt2X/1WYzc72svVjlaFy70rpte9KjNqH8fv7qn2I6++KzfjlmvtYjN0/de339d9HjLk/dO5Tudsydv9V/efq74rv2ofh/qncbRlr7m37z90/5NyR833PV3wfY839OvGdY9G3CDTkZjR/JOtK4NElxx/GXGR7NfNlbF31XEbs+DcA/wN+btE25O8/hKHu0O/v49p9+l8NfBB4O2aFuI3v3LtSeu27ErP2Ydz+vmsfwvu7MmT8cst9bMbsn7r2V/W/jJhzf8jcp3Afypj9bfrPzd+VkLUP9v4p3IcyttwP7T9n/9BzR473PZ/xqxhb7n3Eb1n76Vsoerp53dlzzpydwAngho7jz2C+nu+S1vuXAL+1aD9m/FnAG4Fv8/ydzPvI3d+Wddyh39/HtfvyPwB8ALNZ+71LjofIvSul174rsWofxu0fovYhvL8rtuOXY+5jMmb/1LW/qv8uYs39IXOfyn0IY/a36T9Hf1dC1j7Y+adyH8IYcz+k/5z9Q88dud73fMWvYoy5d4mfr/Ucax/o++jZfc3rh4E7MF+ddmLJeRvAm4A/A0/2tHcNcD1wG6d21T4HkyQbYsXvxXzs7hrLdkvx34F5ZG7OLmA3ZoOr+5v3hrqDnb/rtfto4yDmF+cyjPN8tf2J5gfC5d5m7PsovfZT+9v2P1b/ELUPdv6u7q7xYDd+ueY+VvxY/VPWvm3/fcSY+0PlPrV76tpP7W/bf67+Me6boX73U7vbtjHW3Jde+zHmjpzvezHqZ6y5Hxr/QozXBPNlZg+1T+h7ouhm4B7Mpk33Yx5l273kvNdikrJqU6cfAp8EvojZWGkv8E5ObZoNZkOpk5ikpogH8/VxpwNHV/jMKcV/T3ON8+u8qvn3VxbOGeoOdv6u127Txqr4j2N2f/8V8K+Fn88snBMq9zZj33f9pdd+an+b/mG8/iFqH+z8Xd1d48Fu/HLNfYx4GK9/ytq36b/v2iHO3B8q9zZj73rtffGpaz+1v03/kK9/jPtmqN/91O62bYw196XXfoy5I+f7Xoz6GWvubWsfzDecHQMOAWdiFs22PBDU90TRU5jB3gecjxmgZQN6YfNqs/v3weani/Mwj0n9I1H8OpTiv4lZEfWNrb+r+6o2VsWndN+06H/Mtb9JWn+b/tehFP8Q7mDnv2nRv2vuXOeOdYiV+xjx61CKf8rat+nfR+3Gnvt9ucO45/3U/rnXPoSf+1P93ZODu00bQykl96XXfoy5Yx1i3fdi1M9QSsn9EO9NzObVjwC/wywqbm1wOp0OaDM4twOfBX6dKD41NfvX7A7yl3+9/jW7g/xr9vdx7TX7l+wO8q/Zv2Z3kH/N/rrvFZT73BaKhBBCCCGEEEIIIUQi+vYoEkIIIYQQQgghhBAVoYUiIYQQQgghhBBCCAFooUgIIYQQQgghhBBCNPwfamgBkkU4UM4AAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$\\displaystyle \\left\\{{\\gamma}_{0,0,0}, {\\gamma}_{0,0,1}, {\\gamma}_{0,0,2}, {\\gamma}_{1,0,0}, {\\gamma}_{1,0,1}, {\\gamma}_{1,0,2}, {\\gamma}_{1,1,0}, {\\gamma}_{1,1,1}, {\\gamma}_{1,1,2}, {\\gamma}_{2,0,0}, {\\gamma}_{2,0,1}, {\\gamma}_{2,0,2}, {\\gamma}_{2,1,0}, {\\gamma}_{2,1,1}, {\\gamma}_{2,1,2}, {\\gamma}_{2,2,0}, {\\gamma}_{2,2,1}, {\\gamma}_{2,2,2}\\right\\}$"
+      ],
+      "text/plain": [
+       "{gamma[0, 0, 0], gamma[0, 0, 1], gamma[0, 0, 2], gamma[1, 0, 0], gamma[1, 0, 1\n",
+       "], gamma[1, 0, 2], gamma[1, 1, 0], gamma[1, 1, 1], gamma[1, 1, 2], gamma[2, 0,\n",
+       " 0], gamma[2, 0, 1], gamma[2, 0, 2], gamma[2, 1, 0], gamma[2, 1, 1], gamma[2, \n",
+       "1, 2], gamma[2, 2, 0], gamma[2, 2, 1], gamma[2, 2, 2]}"
+      ]
+     },
+     "execution_count": 127,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Find the free gamma values\n",
+    "{a for a in ftmp_sym.free_symbols if type(a) is Indexed}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### No electron-electron cusp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 128,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA7gAAAAcCAYAAABLXBM+AAAABHNCSVQICAgIfAhkiAAADRNJREFUeJztnX+wFlUZxz+XTKMLYdYklhWaoBIjKMSkBUKAms0UmQ39Ecztx2QyDZYjNTQ0czGnnEGSSKmsxpuOTWrMZJaOlcVYFIlMlhJiOVBaDGqmhoUo0h/Pbnfv3t13z+6eH/vu+3xm3tl7992zz9nvefY87zl7ztm+wcFBFEVRFEVRFEVRFKXbGRM6Ay1iFbANeBZ4ArgdmJZz7HTgJuAx4ACwG7gReGvAPHWTLUVR2ofWIe1Ey1VRFEXxijZw7TEP2AicBbwLeBH4OXBM6rhlwHbgeWAJMCXaB7CiwMa5jvJU104dW4qiuOds4KjQmShgHlqHdAO+4pCiKO7phtigKJ3I9OG+nCHKNwDnAScAzznNVvcwE7gP+DjwHYPjxwHPAIuRHmuQAH8PsBK4OiPNMcBTOef7EPAv4C7zLBvlyYUdU1uKovjhaGA1cFnojJRA65Dm4SsOKYrih26MDYqSJNOHs57gzgI+DFyJm8btL4DDwBwH53bJduCHwBVIgC5iPKJvssG6HvgN2Y1byG/cnoj0mtdtdGblyYUdE1uKovjjaaSD7qLQGSmB1iHNwlccUhTFH90YGxQlSaYPZzVwv4TMlfm6g0z0AWcALwG/d3B+13wZmEjxUGKQxuz9wNbo/1OAtwHXVrD7ReC6CumK8uTKjoktRVH8cisSAPpDZ8QQrUOaha84pCiKX7otNihKmlE+nG7gTgEWArcA/3WQgcnABGAXsN/C+QaQp8HzLJzLhHuBhxARX9bhuLXAXOCDwKFo34xou72kzdOA04HflkxnkicXdkxs9SoD+PXXXmUA1TmLQ8jcx0tqnGMAP9pqHZLNAGF821cc6lUG0DrLBwOozll0U2zodQZQnbMY5cPpBu5HkaesNzvKwMxoW7aR54r5iKOsBWYDtyHDpg6Tv6Lx94E3IR0BWaxDFo1aAPwlsX9stC3bsP8k+UPCTPOflydTO7ZsXQC8APwOeHOOnTXROT/RIS+9SFlfVa2r0Xbd7kDu9b4Atm3VV20vI5dUiXngPg5pmVZHY4Mf2q5bN8SGmLaXhSvartsIH043cBcirWBXQ4dmRdv7HJ2/LGdE22nAr5Ch098Evoc8qc1iS7RdlPHdBmT+8nzgT6nvHoy2c3PO+8qc/e8nfzi3Sf475cnUji1b+4CfIRXYZzO+PzHavw34doe89CJlfVW1rkbbdbsfeCNyfb6xVV+1vYxcUiXmgfs4pGVaHY0Nfmi7bk2PDUnaXhauaLtuI3z4iMQX/cgw2p24Wzm5qQ3cdyLLTJs07LdF23RDdSMSwBcjPU8To/37o882pHfhGqQxuwXpJZmJ9JSsZvTwr8nReYp+WOTlvyhPpnZs2dqC/FD6J8O+kGQDcCSwHKnglGHK+qpqXY226/Y08t7tuUgvrk9s1VdtLyOXVIl5PuKQlml1NDb4oe26NTk2pGl7Wbii7bqN8OHkE9w3IPNK9zoyPAaZw3MIaWU3gfimugTzp9bPAAeQYcpJLkZWh7wb0TD+JJetvgC4CrgU0WAb0luyhewfD/HQjLwyKcq/SZ5M7Ni09TzSg39qav97gfcgi5g0pQOkSVTxVdW6Gm3XbS8wNYBdW3UItL+MXFGlHvEVh7RMq6GxwR9t162psSGLtpeFK9qu2/99OPke3DORV9jcAizJSLSH/DHbWdyE9NrGnII8Hd6BDEMoS1n730UmY+fRj6wW/SRwHNm9FdcCxwIXpvb/Pdp/xKgUdlkBfBXpUXkh9Z1J/m3YsW0L5D3LS5GhBI8h85N3ID+CpiDvWex29mDPX031z/LXtmu9B7v1QkybdbsDeSn6goLj9uDfh8vQ5jKC5sQ8X3EI2l+moLHBF3vQ2FCWJscG9eFi1IcTPpxsoMWrJr8iJ9EjyJNLU/6R+r/u8OT1yMt8k8wA3ocU6p7Ud0VPiacjT5V/Qv4NtZrsBt9Y3KwynWY8onlWHkzyb8OObVswPKdiKnJzrQJOAD7GyBtrFfLU+2Sk12lrtO9BzKibfi6wEhlGfhyy8ucPDNPa9FdT/bP81ZfWdbSqk952vRDjSzeQ4UArkeveAXwamYdkQhXdnkWupYgQPlyGNpcRNCfm+YpD0P76CrovNoTUqk760LGh7nWDxoYkIX0Y2hEDYkx1g3rXXTd9LR9ONnAfj7avyUlU1KNTRNzArbqC8vqMfQNIQQ8Bm0ueLx4S0WmuQVYvxhjE4XaXtFeVwzn7TfKf9wS6jB0XtpI31yPIMO2twPWp4+Yh87e2IauiXY4sAz4VmctVRN30/cAfonxtMjg+iU1/NdEfsv3Vl9Z1tKqT3na9EONLtyXI07HlwK+R4Zx3Run/ZpC+im4vYbZSZggfbmI9EqKMoDkxD/zFobbXV9B9sSGkVnXSh44Nda9bY8NIQvpwW2JAjKluda87qA8nG7h7gSeQHlEXxK8IasrY7vimysvP8cCjyNDqXYn9JyPi+ZhHvB95WvxyRvdcFeUf8p9Al7Fj2xaMvLkWIn64nNE/os5N/b8UmQP9DuB2Azt1098ZfUJjon+ev/rSuq5WTdE6xpdulyKB6lvR/yuAdyOBYJVB+iq6TQD+XTJNXUx8GJpZj4QoIxdUjXm+4hBofVUWH7EhtFZN0TrGl24aG4YJ7cNtiQExprrVve6gPpxs4B4G7gE+AJxE/vtSq9DUBaYOAg/kfD8D+A/w59T+t0fbXzrKV5JHo+2rkFXPkhTlH8zH0XeyY9sWiG8dQoYbHI2sLN1pBeeY8YgvmfTQu0gfChP98/w1lNbdjg/djkQ6/q5K7f8pcJZxTsszAbv1uwkmPgzNq0dClZELqsY8X3EItL4qS4jY0Ov40E1jw0hC+nCbYkCMiW51rzu4D6ffgxs/Ak73jtblVORR8wHga8j7ldKfKy3b7MRRSM/FA8iNlcV04I+MnhNwDuIYtznL3TA7o+3E1H6T/B+PdFqYPJHPs+PCFtF5diM31uPAFwzTrUc6SKq+p7lu+hCY6A/5/hpK627Hh26vRVau35fav4/se9EWx9L5ndi2MfXhJtYjocrINnVinq84BFpflSFUbOh1fOimsWEkIX24LTEgiYluda87uA+nVwHeFBlfhsybsUU8PLkfmcScxV0W7RUxDRlu1Wk+8AxGP22egLzL78cM92q75CGkx3wGMjk7xjT/WT1eZey4sJW0eRLwOeTdVUWsRSacz0E6GMpSN30oTPSHbH+N8a11W/ClW3pYUF/GPluMB95CuUUi6lLGh5taj/gsIxdUjXngLw4l7Wl9VUyI2KAIvnTT2CA0wYe7PQakMdWt7nUH8+H0E9yDyITg2ciQYlvcgFxUp895Fc47FKXdXDLd9ijdRR2Omc7oG2oZssr0upL2qnIY+BHDcxRiTPOf1eNVxo4LWzGvjo6/1eDYdYj2C6g2fKZuelsMUd5fTfSHbH+N8al1ExiiWr2QxrVuTyI/yNO9ma9jdK+nLU5H1lsoWtAjjyHc+nDT6pEQZdSJIfzGPPAXh2J6rb6C7ogNbWAI/7GhChobRhLSh9sSA9IU6Vb3uoP7cLqBC3A1srrV5Y4y0A30I70AyRtqLDIpehN+e7i+gQyLLkunHi+bdqrY6kMqrF3AcwXHbkDepzyfakNn6qbvBrL8Ncan1m3Ch24HkQC/KLV/EfJOchecgyz4YOtVPTZpYj0SooxC0KkOAX9xSOsru9iKDcowPnTT2DBMaB9uYwww0a3udQf34fQQZZB5skuRoNFPb1Z8p0Xb5KT3ScB1SO+JT+4FHkZes1RmBerplHvSXNVOFVuTgXEULwawEfkBsxhZPCTuCdoffYqom34cMoQjZhLyg+0pzJY490WWv8b40rquVk3T2pduXwFuRO6/LUhP9uuRBoUJZXQbA5wPnG14bt80tR7xWUah6FSHgL84pPWVXWzEhtBaNU1rX7ppbBCa4MNtiwGmutW97qA+nPUEF2Q15TX0ZuMWJCg/jMwditkJDDL6xco++DzFQziSFPXG27JT1VY8/L3o5roYGVN/NzLsIP5cljhmABlCN8lB+llRHuN8ro3+btrohix/jfGltYlWddP7xJduNyMvPl+N3ENzkEr6r4bpy+gWvxze92sgTGhyPeKzjELRqQ6J8RGHtL6yi43Y4EOruul94ks3jQ1CE3y4bTHAVLe61x3Uh/sGBwdzrktpGB9BVj3bbHDsmchLlcfT+QdLXTt1bdlgDXAhUgm+GCB9L6FaV6MJuo0HrgA+Q/OGoIHWI92CrzhkAy1Tf6jW1WiCbk2PDb5oQll0I03QLdOH857gKs3jeuQ9hCaY9MbbsFPXlg3OBz5F9RujbvpeQrWuRhN0m42sIdDUHzBaj3QHvuKQDbRM/aFaV6MJujU9NviiCWXRjTRBt0wf1ie4iqIoiqIoiqIoSivQJ7iKoiiKoiiKoihKK9AGrqIoiqIoiqIoitIKtIGrKIqiKIqiKIqitIL/AWFulDB95ECFAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$\\displaystyle \\left(- L + r_{i}\\right)^{2 C} \\left(r_{i}^{2} \\left(r_{i}^{2} {\\gamma}_{2,2,1} + r_{i} {\\gamma}_{2,1,1} + {\\gamma}_{2,0,1}\\right) + r_{i}^{2} {\\gamma}_{2,0,1} + r_{i} \\left(r_{i}^{2} {\\gamma}_{2,1,1} + r_{i} {\\gamma}_{1,1,1} + {\\gamma}_{1,0,1}\\right) + r_{i} {\\gamma}_{1,0,1} + {\\gamma}_{0,0,1}\\right)$"
+      ],
+      "text/plain": [
+       "         2⋅C ⎛  2 ⎛  2                                                    ⎞   \n",
+       "(-L + rᵢ)   ⋅⎝rᵢ ⋅⎝rᵢ ⋅gamma[2, 2, 1] + rᵢ⋅gamma[2, 1, 1] + gamma[2, 0, 1]⎠ + \n",
+       "\n",
+       "  2                     ⎛  2                                                  \n",
+       "rᵢ ⋅gamma[2, 0, 1] + rᵢ⋅⎝rᵢ ⋅gamma[2, 1, 1] + rᵢ⋅gamma[1, 1, 1] + gamma[1, 0, \n",
+       "\n",
+       "  ⎞                                     ⎞\n",
+       "1]⎠ + rᵢ⋅gamma[1, 0, 1] + gamma[0, 0, 1]⎠"
+      ]
+     },
+     "execution_count": 128,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# First derivative of electron-electron distance should be zero at r_ij = 0\n",
+    "ftmp_ee = diff(ftmp, rij).subs(rij,0).subs(rj,ri)\n",
+    "ftmp_ee"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 129,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjkAAAAcCAYAAACDFa7BAAAABHNCSVQICAgIfAhkiAAACGlJREFUeJztnXmsHVMcxz+PUtI21lBC7EpV+1BiV0sJEruI/QYlbaVEbLXl8YdIqpRYS+JZQxBE7HtsrRJVNFUVz5JQS+3EU8sfv5m8MW+Wc+fMme3+PsnNfe/cOXNnvt/5zf3NOWfOdPX09KAoiqIoitI0VrCoexHwL3BDTtuiuGEqsAD42Xu9CRxc6hZ1HtOBeYj+3wKPA2NK3SIlDfVMURpA1iRnZ2AS8uOpVJsvgQuBHYDxwIvAo8DYMjeqw5gA3ATsCuwDLAeeB9YscZuUZCagnilK7RmSoc5qwL3AqcBl+W6O4oDHQv9fDEwGdkGT1KI4IPT/icBPwG5IC4FSPdQzRWkAWVpyZgMPIS0CSn6sBZwGPAIsAf5ATqqvIQmlTdeiz4rAscBw4I0c1qdkYwTi57KyN6QBFBE3oJ7lSVGeKUrbLTmTgM2RqxolX44Gbga+Al4CPgfWBY4AbgcO9Jb5N8O6t0XG4qwC/AIcBrxvv8lKRmYB84E5ZW9IA3AZN0HUs/woyjNFaStjHgVcCRwP9LvZnNrTQgJzQoa6i4FDgA0QjacDpwBbAV8ARyIngSx8BHQjY6luAe5CB1EGaZHdt3aZAeyJnMT/LuD76kCLasaNj3oWTYtsvhXhWafTorhzWqUJJzl7I8LMAHZCxnMs88r2A9YGPkAG4S0H9gKmeH8P9dZxBPAXMBfYKOZ7L/fWeXpO+9EEXkT6+v8JlX+NJCYQfcAmebaNt0w/0iz8NnJCmQ+cHViHepYdE/19ZgInAfsifgRRD7LhMm5APXOBa8981J9sNEq3cJKzvfc+BngVOQhvBe4D7ke6PboDr7e98m4GWneWAs8hB+H5Ed+5qVc+D2maVNL5y3tfHvFZkmeLYta3AtJ15aOeZcdU/+uBE5AT9cKI9agH+WMbN+pZ8eR5rlN/stEo3cJjcvyDaHeklSbc//x96P/fkEz6g0DZ68Dh3rLjI77zemBlpAUonMkrgxmCXEkCPB3xeZpnVwFPIM3AI4DjkKuk4Fw56ll20vQHuRX5BGQs1DJgpFf+q/cC9SBvbONGPSseW8/CqD/ZaJRucS05Z2E3wO5P5Mpn61D5IciP62ykFUhJ5yrkyuVJ4JmIz9M8Gwncg4zLeQHYERnY91RoOfUsGyYxMxlJMF9ABlv6r3NDy6kH+WEbN+pZ8dh6FoX6k43G6NYVeKzDMGR2z++A9bDP0O5C7sLaEJmQblXgQ+TEsSXwg+X6y6aP+P7KKO5EBoO1wzTgOqQpdjcG376qnrVPH/n5lrf+0HwP+tC4qSN9uPUtD89uRO7SOipU3nR/+nDjTSN0C3ZXjUNadp4gn5O130c6GhFoOrAJMg9CUJzpyECnUUj2OMcrC3aBJWFbf0/gPGRG4PWQOygeMqg3C1g9VNYNHIocRH2hz+Ybbo/PVCToFyKDHqPm56irZ1k1z6N+nr7lrT+Ye1Cmhjb1NW6yxw1IF8F5iOYfIjcQvGpYtypxEyYvzy5hYExPkKJiCsrxx5U3prqB3X7b1k/ULZjk+E2BcxNWFpcpRxEU6BNkoNIc4I7QchOQ/u95QBdwBTJ9+mjMJt6yrT8MeM/brocNlveZFVHWQg6sXuDlNtYV5mzgWuTkty/wTcxydfUsq+Z51M/TNxP9wY0HZWpoU1/jJnvcHIMkA1OQifMmI93Oo5G5ZtKoStwEydOzuJaFomKqLH9ceWOqm+1+O9UtKslJ6meLy5SjCAq0n/ddUxg8wZPt9Om29Z9i8PiUMrkA6ZueD0xEmmfjqKtntppXxTMT/cGNB2VrWBUPfDohbs5BfrRu8/6fhoyvm4xcZafRZM82QG6u2AoZfxikqJhqmj+mutnut1PdwklOP8kz4bbTB7cEmTjraKQp7QbgXYN6ttOn13n69UuRq7t3gP1J34emeFZXTPSHYjzoZDohblZGmuOvDpU/izxEtG7k7Vk38DvwccRnRcRU0/wBM91s99u5bn6SMxTJ1hYQP5txUqYcRT/wKfIYiG+Qg9oE2+nT6zr9+slI0P+N9EVOi1imD8l4oVme1RET/aE4DzqVTombtZFnzy0NlS9FrrLrhAvPxnmfR43XKSKmmuSPj4lutvvtXDc/yRkDrIRk1XEkZcpxLEIEugD40WB5f/r0Pcg2fbpt/TLZxHtfkf/PRhzkFQYCvyme1RUT/aEYDzqZToubcFdBV0RZ1XHlWdKA2qJiqgn+BDHVzXa/nenmJznveCtNIilTjmMNb/kHDZadycDsouHp002wrZ8HvQwEZrv0eC9TmuBZVeilfd9M9Af3HjSBXjRu0vgOSYZGhsrXYfBVcFH0ks23Htx4NjPhc9cxVTV/eskeU0HSdLPdb+e6tfOAzrRMOUwXcuB9hMyMnETa9Olp2NZvKlX2rFNw6YHihirGTT/yYz8xVD4ReKON9TSRYcBmxHtWREw10R8T3Wz327lu4cc6JJGWKYfZAhhO+gAvk+nTXdYfjjTH+WyMnOSWYXb7WpWpqme2mtfJM1celK1hnTxol6rGzTXA3cBbyNT7ZwDrM/BQyzSa6tlY7z1uUHJRMdU0f0x1s91vp7qZtuSkZcpRbOe9pwlkMn16C+mf29hB/fHeNvrbOcP7+4qU7a46VfbMRHPb+lXApQdFaGhbv45UOW4eQMawXOJt3x7AQcBnhvWb6tk4YDEyjiqKvGKqRby20Dx/THVL2+8WJeoWfKxDErsgk/SMIP5AcsnlyKRc44h+Oq3r+nVEPSsf9aB+qGdKHHlo24n+lKqbaUtOWqbsmoOAM8kukG39OqKelY96UD/UMyWOPLTtRH9K1c20JUdRFEVRFKVWtHN3laIoiqIoSm3QJEdRFEVRlEaiSY6iKIqiKI3kP8TarQW+yv0WAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$\\displaystyle r_{i}^{4} {\\gamma}_{2,2,1} + 2 r_{i}^{3} {\\gamma}_{2,1,1} + r_{i}^{2} {\\gamma}_{1,1,1} + 2 r_{i}^{2} {\\gamma}_{2,0,1} + 2 r_{i} {\\gamma}_{1,0,1} + {\\gamma}_{0,0,1}$"
+      ],
+      "text/plain": [
+       "  4                      3                    2                      2        \n",
+       "rᵢ ⋅gamma[2, 2, 1] + 2⋅rᵢ ⋅gamma[2, 1, 1] + rᵢ ⋅gamma[1, 1, 1] + 2⋅rᵢ ⋅gamma[2\n",
+       "\n",
+       "                                              \n",
+       ", 0, 1] + 2⋅rᵢ⋅gamma[1, 0, 1] + gamma[0, 0, 1]"
+      ]
+     },
+     "execution_count": 129,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Remove the (r_i-L)**C part\n",
+    "ftmp2_ee = simplify(expand(ftmp_ee)).args[1]\n",
+    "ftmp2_ee"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 130,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjYAAAAcCAYAAAByHvVMAAAABHNCSVQICAgIfAhkiAAAChFJREFUeJztnX2MHkUdxz9XEGjaBhXQoqhFK0Us3CkNoVbqVQoNmCCghKhQn4BIWkwlRsQqJFditElFKgFBNPFEJbw1SBQQlHeqxdJYkZdSMZ6oqdVarYriUax//GZzy96+zO7s7Nvz+yRP9m53Z5/Z73d/88zOzswOjIyMoCiKoiiK0gWmOKT9HLAHuKqkvCh+uAB4HPiH+fwMeF+tOeo/VgIbEf3/AvwAmFtrjhRFUTpK0YrNscB5yA+m0mz+AHwWOBqYB9wHfB84qs5M9RnDwNeAdwHvBXYDPwFeXWOeFEVROkmRis3+wPeAc4G/lZsdxQO3A3cCvwa2Ap8H/gnMrzNTfcYS4FvAE8CvgLOBg4AFCftfD/wZmFZJ7pR+4Gikhf3cujOiKL4pUrG5DrgVufNXyuMA4GPAbcCzwH+AXcAjSGHk8tgwYC/gQ8B04KclHE8pxgzEz50x2+YBZwGrgeerzFRHqSKu2sAmpKX2C0j8V436oFTG3jn3Pw+YjdxxKuVyBnANsA24H3gOeC1wOvBN4CSzz54Cxz4S6VuzH9JacyrScqDUw1pgM7AhZtsXkb4411Sao+7iM67axpeAR4EVyHVWJeqDUhl5aslzkGD4CDDuJzutp4cE5nCBtFuBU4BDEI1XAucAhwO/Bz6AFAJFeAYYQvpGXYs86tDOqxP0KO5bXtYAC5FC/KXItsOAxcDNyB2tIvRoZly1jZ8DW4DzkdbbIvQo5oX64J8e1ZVjjSZasVmECLMGOAbpn7HTrFsMHIj0E9htPu8Blpu/9zXHOB14EbkzeFPC964yx/x4SefRBe5DRsv8L7L+T0hlBOIv2DTP3m72GUeafx9DCpTNwIWhY6hnxbHRP+ByYClwPOJHlHOAAeCmmG3qUTGKxFWXtb4ReCNSnleJz/ItTJe980mndItWbN5plnOBh5GL8OvADUhAHInc+Qefx8z6ISZacbYDP0Yuws/EfOebzfqNSBOkks2LZrk7ZluaZ1sSjjcFeSwVoJ4Vx1b/K5G+M4uApxKOtRhpxYl7RKUelU9SXHVZ6/VmeUKtuXg5ZZZvXfbOJ53SLdrHJriI3o20xkQL2L9G/n8eqT0/EVq3HjjN7Dsv5juvBPZBWnqitXdlMnsjd/kAP4rZnuXZauAOpLl3BvBh5M4oPJeNelacLP1BhnqfhfRt2gnMNOv/ZT4gI6CGgKeJ7zSsHpVLWlx1WeuNZrmw1lxM4Fq+Remydz7plG5JFZtPkn0BpfFf5K70bZH1pyA/qNcirT1KNquRu5U7gbtjtmd5NhP4rlnuQuYeOinmWOpZMWxiZplZ3htZvwoYMX+/Hun3sC3lu9Sj8siKq65qvQt4AXkc1QRcy7c4uuqdbzqj20DolQrTkNEYO4CDca+VXY+MnnoDMkncVOBJpNXgMNo/B84Yyc8i4/g20rkrDyuAryJNrguYPDxYPcvPGOX5Vqb+85Eh+DcDZ6bs13WPxqg/rgK6qvUfkRFJWaNix/DrRRnl29XIuXwwsr6r3gWM4cebTugWvrAHkb4Xd1BOU1Pw/PMIRKCVwKFMnthvJdJxaQ5SY9xg1oUfb6Xhmn4hcBEygdXByGiVWy3SrQVeGVk3BLwfuYjGIts2W+Yn4AIk6J9COpvGFb5t9ayo5mWkL9O3MvUPRkHtl7qXvUd1auySvglxFWCjtWssgDTvX4To9CTSsf/hHOnzaj0Vu1F3Pr0oq3y7hIk+OmGqihNw869pcWKrG7hft950C1dsgia/R1MOllQ7jiMs0G+QjkcbkBlYwwwjfRA2IiNCLkOmmz+C9EKnrPTTgF+afK2z2D9gbcy6HnJhjQIP5DhWlAuBK5DC8XhkFto42upZUc3LSF+mbzb6g50HgccHZBzL1qM6NXZJ34S4CrDRehi3WDgT+YFfjkxWtwy4y6R/ziI95NN6CvKD+FuL4/ryoszyLakFoao4cfWvaXFiq5vreXvVLa5ik/YMLal2HEdYoMXmu5YzeQKmJZH/z0aeAy9Ahgdm4Zr+LvNpChcjz503IyMXdqTs21bPXDVvimc2+oOdB9uQF2TOydjP1qO6NW6KRwF54irARmvXWPgU8kP0DfP/CqQP3DLkbtmGPFrPQSpgeVu6yqLM8u0QZFDE4chcXWGqihNX/5oWJ7a6uZ63V92iFZtx0mekzfN87Vlk6OoZyB3CVcAvLNKlTTdvg2v6OrkUuePbBJxI9jl0xbO2YqM/2HmwB3gImahsNvHz3EBxj/qZvHEVUETrPLGwD9KU/uXI+nuQF6b64FizvN/T8dMou3wbAv6NvAcvShVxUod/vrHRzfW8vesWVGz2RWpoj5M8q3Ba7TiOcaS5czbS1HipZZ7SppuvIn1dfBQJ+peQ54wrYvYZQ2q50C3P2oiN/pDPg3VIxWYJyRWboh71K3njKkwRrfPEwoHISLjtkfXb8TeB3omIFrd7On4SPsq3QbM9rv9NFXFSh3++sdHN9by96xZUbOYCr0Bq0kmk1Y6T2IIIdDHwd4v9g+nmj2PydPM2uKavk0PNci9ePitwmAeZCPyueNZWbPSHfB6sQ4J7KdIvJ4m8HvUzeeMqSh6ti8ZCtJl/IGZdGeyPzKX0Q6SyXSW+yre0R2pVxUlV/lWFrW6u5+1Nt2Dm4U3moOen7JtWO07iVWb/Wyz2zZpu3nf6MhhFdHygQNoRkzbtMxzavwueNYVR8vtmoz/k82Ac6VB3DPCOlP3yeNQFRqkurqLYal0kFnYgFaCZkfWvYfLdbBksRUbdXe5wjFGKeTGCn/ItrWLjO06q9i+LUYrHSZgs3VzP27tueV6CmVU7jjKAXHjPED+Tahib6eZ9pu8qTfasX8jrwRXIqIDLErbn8Uhxw1brorEwjvyAR19vcAIyp1GZTEU6Za4j35DcpjINeAvJsVVFnFTpX1XY6OZ63t51y5qgKcwg+Wr6bwWmk91hy2a6eZ/ppyPNbgGzkB+jndgPt2wqTfXMVfM2eZbXgxeQkTWLkMI7WrjYelS3xm3yKAkbrV1j4SvAd5A3b69HWihex8SLIW2w0XoWcB3Jj9zaxlFmmdSxuKo4cfWvaXFiq5vreXvVzbbFJqt2HEfQlJ4l0DJkJMG9yJDX4PPp0D495NnbLA/p55k8BvlcY/5OumNuC032zEZz1/RNoIgHIKOjVhF/x2TrURUau6ZvOjZau8bCTUifk0uQ6+Q44GTgd5bpwU7rp5HHQWMp59ImBoGtSP+1OMqKkx7p2rv617Q4sdUt67x71Khb+JUKacxHJtGZQfKF5JNVyORmg8S/AdZ3+jaintVP3R5koR5Vg+rcXsrQvh/9q1U32xabrNqxb04GPkFxgVzTtxH1rH7q9iAL9agaVOf2Uob2/ehfrbrZttgoiqIoiqI0njyjohRFURRFURqNVmwURVEURekMWrFRFEVRFKUz/B+vzKyMSyk1HQAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$\\displaystyle r_{i}^{4} {\\gamma}_{2,2,1} + 2 r_{i}^{3} {\\gamma}_{2,1,1} + r_{i}^{2} \\left({\\gamma}_{1,1,1} + 2 {\\gamma}_{2,0,1}\\right) + 2 r_{i} {\\gamma}_{1,0,1} + {\\gamma}_{0,0,1}$"
+      ],
+      "text/plain": [
+       "  4                      3                    2                               \n",
+       "rᵢ ⋅gamma[2, 2, 1] + 2⋅rᵢ ⋅gamma[2, 1, 1] + rᵢ ⋅(gamma[1, 1, 1] + 2⋅gamma[2, 0\n",
+       "\n",
+       "                                            \n",
+       ", 1]) + 2⋅rᵢ⋅gamma[1, 0, 1] + gamma[0, 0, 1]"
+      ]
+     },
+     "execution_count": 130,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Collect powers of r_i\n",
+    "ft3 = collect(ftmp2_ee,ri)\n",
+    "ft3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 131,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAw8AAAAcCAYAAAAndoN+AAAABHNCSVQICAgIfAhkiAAAE4FJREFUeJztnX+0HVV1xz9JKIQmDxKhGJUfMSIIBRJesqJiE4IhwaK1iKBCC76UUiBQpAINaISXgBpBMKYEEG0J2LKwFMUKUqkBkwYkCdHwSwLFxQvURgIm4YeFJCTpH99zcufNPfPj3vl1733ns9Zd972ZOWfOPXvOzN7n7L1nUG9vLx6Px+PxeDwej8eTxOCqG+AphC8AO4Drqm6IJ5ZzgceAV83n58BHK22Rx9OaXAqsROPkJeBHwGGVtsjj8XgGKJ1gPBxXdQNajA8AZyKl1NPa/A9wCTAemADcD9wFHFFlozyeFmQKcD1wFPBh4C3gp8DbKmyTx+PxdDJHA7u5dlRhPHwezYqfmkNdn8mhjk5iT+BfgDOAjRW3xZPMD4EfA/8NPAN8EXgN+GCFbboVWA8Mq7ANns5iPLrnn5GhjuOAm4EngMeB04A/Aj6UuXUejycP9kfj/PtVNyQjVkc9peqGtACPAl927XAZD/+JOi742YCWjM8ABmVsTLf5/kXGesagB8pPMtbTSdwE/Buawa6KvYC/Bn4APAu8AbwCLEPXTyesdhXBEHSzGg48VFEbJgB/CcwDfl9RGzoJPxbEKrSidiW6vvOgC/XfhpzqS4uXqcfjJi/drmommO9VlbYiHS59PfyZbY4dAWwCfofun2EGI/1xB/Ads20T8AhwVvjgXRwVdAPb0Y1+h6nwQOAkU+EBwGWN/b66+l9HM61ZuALv0x/kTCSn0ypux8nADcA64AHgeeDtwIno+vlTc8yOqhrYYhyOYh2GolWHE9DMahV8BfmU31DR+TsNPxZqfBVYDpyPrrOszAdWAw/nUFcjeJl6PG6s8dAOSncclwBzkUdAq9ONXDidqwMGuxK0CVgAfAk4D92TgywAPgncTX9j4Q60ePDPBCYVB4WyLb0Hzab8CvjjUMWnIpeY9ehm2QzDkHLyEDCpyTpAPuG3A4dmqKOTOBjNfE0C1phtP0NL/Oc1UV8PchE4xtTTCB9Gcr4HGaGWUcAKYD9kiN7ZRLs6kV3Rcu8INHDPRP7dTzRRVw/Ny+0gdO18B/ibJs7dyfTQXL/6sdCfp4A/RKvG2zLUczVaIZuEnlfN0IOXaavSQ/P3MU913AMcj8bCixW3ZSBg9fVfUjPckhgJ9AFbgdFoIh/kMn0lmoyZCvxfqNxVyPjYOfETXmK1yzXLHSddYr73Cm0fhAb7ErQc8gb6MZ911DHOnNNapheiGZoLHceClOLNwNLQ9rNxuyudiDplOVohcTHHnLPdFKRjULuvBiYif/kNZtuxwN5I4XzLfI4GZpq/nQEvBXE/yoSyPbT9t8CN5u8poX2dKrc4mVnjfAu6ATyCMsqsBi4ovaXwV2gsf8+xr1PlUzR+LPTndmQoH+vYl2asAFwDnI4ecM0aDlnwMq2RVmZl0ql9nZaiZbIL8DmUkOUNYC3w9+jZ0Q38hnrDoREd0bb/66a+u0z7X0GugqPMcYcCt6HJ7FfQbPn+EW22E9/PoNX9jWgmfUbM+a8KbZ9mtn8VZXm7zfzO19Fk+Psjzl0kVl9f2UCZjcA/ID3+XLNtBjIcngY+Rr3hAIrNPJtA2EKU8bDCUfhg8702sG134D/QLMEI4Bbz9yhgEUoZGmS8+bY+ccvM9wcc5wP9yCHUz55/Al18YV5EPmAT0QUdZozZvpKaT1e7YC3Lw4D/Qg+vb6GL+Hbk/jIu8HnEbB+HFNRWYKv5fiu0vVPlFiezNRFlBiMXprI5Fs0Gu9xAOlU+VTLQxgLAg+Z7mmNfmrGyAK04HINWx1uNgSbTZu5vRdOpfZ2WImWyK1Ii56NnxXXAYmSM3YT0vnC8Q6M6om3/QUg/3Ab8I3IPPAH4J+DPkI463NT3DEpxfqujzV3mmDGoP65DbjzvNnXNijh/WL88MtCulYFzL0EJTv4ddxxBkTRjPABci4yei4BPIdmtAz6CjDsXq9Gq6kS7IRzzEGU8jAC+Zv4OCug2YDpa8gj6sV6OLtTLkH+ozfwTDqj5BbJCXVbbyeghs4D+aUffiy48l/HwIDIsfhf4LUEWoAEwk/qZo1bH9t2foFWFsJIXFvrvkcXejPtLEeyCZgxBN5MgnSq3JJnNQ0u9L6Abz6lo1rLsdz0MQ0bmU7gDpTtVPlUxEMcC1B5ykx37ksbK9chwOAHd1+wM5OvUlt6rZCDKNElmVdCpfZ2WImWyEOlkl1GLiQUZAdYzJWw8NKsjTkSTylb3m4sMiOlIkZ+GYgVB8nwW3VeGAm8GzrMDKb2/DbVrNjI6ZlDTbYPnD/8Ou30SyvAW3H8nWvEahwwUFxcgPTotq9GqSxz2+j4K2DfimKupf6ZvQEbUJcjT4FUUq9UXc65NwHOoj5dDf+NhEDXr6kTg42b//kiZeRtSdOaZYz6GbuR3UB8A9xJaRjoddfpis70bGQtPmf+3ogfKZOCdwP+a7cOQdbSe+uBsu/S2LuJHbkazUoeEtn/c/I4b0ax8u2Ev3s/RGjfpRpmHZkN+jNvlrBPlliSzUSgIaRRaen0MDeKyM4i9C63wRY0p6Ez5VMVAHAuga/xN3O4FSWPlHPO9OLR9DtCbR+MyMhBl2qrPpE7s67QUJZOJKMvYUpSsJshSpNMdQv9g6WZ1RJCbU3DS+DWk3I4DLqZmOIA8K55GRsIw+hsPUZML65C+GX5PjE3oEw6WtrrxDOoNC6vPxnkMXEC0G52LW4g3HoL6usv9CmQk9EbsuxsZDwB/gVKyJrGOQJxx0G3pIPSeAJCVeDla3puGLsJT0HLRZnOM9RcMWm1B7Ez4EPM9FF1cj9I/WM4uZQddly5DltQs9MAJYh884e1B1qCZXGuN7Y6W2l6mfpmsHRiG5LMeWflpmEK6YOk+6lN73Wz2PeDYl/b8Qc5HcS1riM8G1UlySyOzHnRD2Q3YB7kOpTUc+shPbjaOKendIJ0knyj6KHY8DMSxEGQDis8KkmasDIr49KY4Zx9epnmT9pm0EKV/jKKPYmTTSX2dlrxk4uJvzXdUpk2r7wUV60Z1RNv+56hfvQM9Kzfgjss7ABkYYQ+MkSi70MPo+baN2rV0EHpRq8WefzX9V6WGo0yWz6PJgTBjzPevHfsso4m+h7k+PTF1QU1fXxZTRzg+2fJOFANiSZt46BUCEz/BlQe7BDIf+LsUFR2Nljui0nK9w3w/b77HmvOFj7fGw/uRL9r7zPl/jqyvMF3Istzq2Gexvn2HoovjUuTjFn552qVolcUGZj9stqV19clafjKyosej/joZ96Aeiwy9cIaPPJhP/XLaOODPUf/3hfatbrD+c4FvopmgqcTnZS9Lbmn7PUv5ImUG+crtDfOdFGuRVj5l9G9R5YscD604FkAuHBejvnoSzZJFLb+HabSvd6d2vVnaaayEKUKmWa9/KF6maWU2m/hndVGySdvXkK2vspbPQ9aWvGTiYjpSzMPJayxjULzJbwLbmtERB6OYlTCjkSHwferbPhxlHnowtP0I4D6UHXQFigHdYMq/G616BGfc7fnDKws20c99uFMwdyPF+jnHvqKw+nqaFYMgI5BhZl+5MAvFPiwk+d1Or6J+A9zGgyuWIEwXsAf9l5WCDEEXznq0nAT1wdKWh5BA7MrDdab8uUTnyk7KoR28cfwaraA8TG1GwzIF+dKuRJbaXOCnplyalw9lLT8MCf9m4lP72aU8VxYsy0I0SE5Kcd4g8x3betDNexHZUuVdAHwDKTJT0fUQR1lyS9vvWcoXKTPIV25WLlEzFZa08imjf4sqX9R4aNWx8Gmk/M5Es1jnAPea8s/HlLM00teD0cMr/JBtp7ESpCiZZr3+y5BpGplB8mpmUbJJ29dZ+6rM8ZNEXjIJMxStjP8St+51FJrNvjewrRkd0bbf5VI2PmbfkbiV/u+i+40r5e9cR31RwdJx76/oQnG4S4nXS/OOeWjGeBiKsm8djn7/FUhGF6Hr9usJ5bcTyLbUrPGw2VQ0MmJ/D7Iqv0atQ6MCUTYin7EJKGB0KgqgiWrH62j26g+Itp6DN45j0e+cSb1wjwv9fxqyID+E0vElkbX8vfQfcFHEDSpLM7MJRTIL+QGvRq5vL6coU5bc0vZ7lvLtJLN1yAf14ITj0sqnjP4tsnzetPJY+DxS0r5t/j8fxd2cg2Zrk2ikrw9GD5/w7HE7jRVLkTLNev2WIdM0MtsXJYN4HzUFsSzS9nXWvipz/CRRlEy2mc8+EfvnmO+gbpdFR3Qp6eNj9lnf/+D590MrDz+h3nAYQS1OIFhflI5q648zXJJejJd3zEOjxsMQFLw+GWVXutxsv4raytn1uNO0WvZErmFALeZhMFqa2Uwt+COOLWimaz/qc3ZPRZZ4H/3fYNdt6n/SUd8y9PKgb6Gb8GzHMZYXzPceMcc8iy72k1GAVJwxEqQL9UWaGbsiykfRjfo87s3DG2mNrCMgH8N5aEBNJd2DFaqTWxG0k8x2oJmTvZFvZxTNymcg08pjYVf0UL4vtP0+NJuYN3Z1+YHQ9nYaK1C+TBuhLJmmkdk4pIxU8abeNH2dta/KHD+L0H26J+aYZmWSVPdWc/y7UNxrkFnUdMCgAt2sjrgFt8tllOeKLRfeZ4Omx6CJZsteKGZiX5RSOTiR0W3KhdNA23a5VlHi2hVkNPnFPFh9fTvxsg6yEGUhuwsZC5aXkNGwD3qPQxx7UtO/d648HIL8xlZRn6M6ii8iq+5u4F9R5PpYNBO2Fs3G2KDmXVEmikdxzx49iIJrhqN4h7gHnzVuRhGdk3YLWho/EC2LfSnND0JLqKtpPktB1vIudkOzJ48R/b6GKmd4wnwWLYltQ36f5zuO6cMd0FWV3PKm3WQGWjL/JBq/US/falY+A5VWHwt7oxmp8EudXsT9IresTEd98cPAtnYbK1XItBHKkGkamYH0gceoJiVqmr7O2ldljh870Ruln2WRSVLdICX/FvScuB2lPp2CXGBeQEZCWIFuREdMan+3KeMy1MNZPEFK8f3ojfDLkSvnO9Cq0APo9/+KmpFhz7+a/v2wG9KPH49oV9yKSFFYff1V6t9TEeQm1OdzgLPQ/eoU+icsAqVznYlc+26gPibN8nb0PgugZjzYDmgkUGwxsiAvRwF7oMF6BfKdei1w7OHI+ouyzqwP7Er0QpA41iCjYRzuVYzgcQeizt2UUCeoAyejPL7hzk1D1vJRHIb6Lu7irHKGJ4wNqBlC9JuSlxCdDaJsuRVBu8kM9FB4EQWRLYw5rlH5DGTaZSyEXTkGObZlZU+UtvFuArNXtN9YKVumzVKkTNPIDCS3RhNs5Enavs7aV2WMn8ORTnVPxP4sMkmqG/R+r5EoBewpaIJ3GZqt/gHSydaGyjSiI8a1/wBkqLmCta1yv4r6e95n0BvprRvZ48jN7HEUOxV0Q7LnD+uodnuUK9h43Kldi8Tq63tQcz8Ksx399rNRYPQTKFXxm45j1yOj4UJkZLjikLpQUPrORADWeLgV99v5kliCLLskVhEItHBwMfqxcUHSlh3I+ummf7qpMCNNnXekaN811N5cGjXrWmT5OJL6DvKf4VlEcylZQakTezOcu0y5FUUVMoNsctuClpK/gvw4o9wpGpFPp7CI5vq1l9YeCy+jB+6o0PZ9qJ9NzcrpKGDvmtD2dhsrvZQn02YoQ6ZpZAaSW1jeaVhE8/exIEl9nbWvyho/I5D//jVEBzs3K5M0dVu+aT5h4nz589AR18bs20x/t6QgL1F7cWOYcH1R50/q1/C7RMqgEX39RvNJ4iLzieJIFBu5Mxh/cPSxpXEq8qO7gfSv2b4RLYFHMQgNkqdJTj+1gNpDN+zrloas5fOg6hmevChTblXTijL7BsoQMjdifyPy8WSjjLGwBT0cp4W2T0NZ8PJidxQ8eieNpcC0tOJYaYYyxk9ZMk1iGJqprEpuafo6a1+V1deTkLv3tRnrcckkr7o9nc10lBRg5wTOLtHHFsr+yGh4D7IMn0T+VmlZgV4tPgH3ctJ7kU9YUjDa9eihewJahrMzCFFvJcy7vH35iGU0elBuIF2aN0uzMzytRllyy9rvecitFWX2JsrWcwx60IQfumnlU3X/5jWuqqSssXAtSmm4AsWenYXSLqaZrYJ0fT0a+d8uSllnmFYcK81Q1vgpQ6ZJHGG+0wZ05k3avs7aV2X09Y9IfgdPGlwyyatuT+cyGDgepdbtt7EKPoICcE5CwXPTiU8R5eILaKC6sKm1km4c5yBfrsVoScZ+gss3PchVanQB5SeYNtp2Xm3+jpr5dVH1DE+elCW3NP2etXwcrSyzpSjAyjVbl1Y+ZfRv1vKtTllj4XvId382uh4noQdF0H85rnyavn4Kufr0JfwWF608VhqlrPFThkyTGIsm+Bp9rudF2r5O6qseovspTfmkOsq8V1UtE097Yl/YGIxRYVBvb28lrcmJGSgA52cFnmMOMnLGkj4TVZ7lk/ggClzqwt8UgrSy3LzMWls+nUY797UfK27aWabtRB795Pva0650AVeiLKj9Ys5aIeYhCzcT/76HPDgeOI/mB33W8kn42QQ3rSw3L7PWlk+n0c597ceKm3aWaTuRRz/5vva0KxNRvFpdsop2X3nweDwej8fj8Xg8JdHuKw8ej8fj8Xg8Ho+nJLzx4PF4PB6Px+PxeFLhjQePx+PxeDwej8eTiv8HPORdRkGrIr4AAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$\\displaystyle \\operatorname{Poly}{\\left( {\\gamma}_{2,2,1} r_{i}^{4} + 2 {\\gamma}_{2,1,1} r_{i}^{3} + \\left({\\gamma}_{1,1,1} + 2 {\\gamma}_{2,0,1}\\right) r_{i}^{2} + 2 {\\gamma}_{1,0,1} r_{i} + {\\gamma}_{0,0,1}, r_{i}, domain=EX \\right)}$"
+      ],
+      "text/plain": [
+       "Poly(gamma[2, 2, 1]*r_i**4 + 2*gamma[2, 1, 1]*r_i**3 + (gamma[1, 1, 1] + 2*gam\n",
+       "ma[2, 0, 1])*r_i**2 + 2*gamma[1, 0, 1]*r_i + gamma[0, 0, 1], r_i, domain='EX')"
+      ]
+     },
+     "execution_count": 131,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Convert to polynomial to extract coefficients of r_i\n",
+    "pt3 = poly(ft3,ri)\n",
+    "pt3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 132,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAdMAAAAZCAYAAABq+sTLAAAABHNCSVQICAgIfAhkiAAABnlJREFUeJztnVtoHFUYgL+0peCl4CV4Q9SIiEq9FMUHJbJVg0ihalV80GpAUaxSvEBDheLGBxHUGotEUaEpgi8iKqL1RrtVK9VaVJAQJWItolaD9daqrRof/ll2Mju7c86cmTM72f+DZTdz5p895+s/PefMbXuq1SqKoiiKoqRnTuhzBZgOvSaKqJCiKIqidCi9zOwnp+sFc2JW3gIMA094qVr5ORK4BXgJmAT+BH4F3gduJt6xomSF5l92qEsliX1I/zgMfBMumBezcg2o5l6l2cO1wJPA98BmYBdwNLAMeBa4PFhnutUGFMUBzb/sUJdKEvto9I8V4MR6QVxnqtjxJbAUeA34L7T8PuAj4GpkZ3zRf9WUEjEIrAcWIwNaUzT/skNdKqkxPWyxDDgAfEioJ44wjIzYbs2gXmViE/AqM3c+gB+Ap4LPldBydRmPekmHbf6Bum6FusyOrvNi2pnuBt4GzgdWxZSfHCzfjhwOUYQDwfs/oWXqMh71kj1x+QfqOg3q0o6u82LamW4FrgL2AufFlK8D5gMraB7VdSvzgBuDz2+ElqvLeNRLtrTKP1DXtqhLe7rOi83VaX8D48DpkeVLgSXA08DHGdVrNvAQsBB4HXgzUqYu41Ev2dEu/0Bd26Au09FVXmwv9Z4AFgDHB38fBIwAU8hJ+jqrken7b8BPyHmIhRbf4xp/URDzHXJM/hqL2CxYCdyL+FreYh1fLl1d+HZp6qXodrnE76T5XrX1QdnmmLIxy7qZ5B/4y0GQGcjXwF/ADqDfIrbI/Tlrl1m0pUwuTb2AW7tc4529pOlMAc4I3lcDfcAQsCe0XgUYBS4ALkbOM7wDHGH4Pa7xhwCfAXcarp8ldwCPIyOyxcDPLdbz5dLVhW+Xpl6KbpdL/AiNe9Xqr1eCsg0xZS9bbNs0/8BfDl4X1OlBYBFyCHAjcIJhfFH7cx4uXdtSNpemXlzbVbgX21tjwmK+Qk4gb6Mxqq5zWeTv5cjNzxcivX8SrvEbg5dv7gIeAz4HLgF+bLOuL5euLny7NPVSdLtc4kdilg0CVyCz0FrK7drkH/jLwXuQdj0T/L0SuWfzduQ/1ySK2J/zcunalrK5NPXi2q7Cvbh0ppcG8StIvol5ATILbjeyyzPeB0PIuZVPgQHkMEY7inLZ6aT10u3Y5h/4ycH5wLnAI5HlbyEz3U7Ep0sbyujSxItruzrCi+1h3kngX+QpIEuQp4V8YhA3giTmNsvvyyq+HWPIP+ygwzbWIDvfDmQUa7LzFeUyT8Zwd5nWSzeTJv/ATw72AnORWyXC7AaOMaynDWO45aBvlzaUzSWYeXFtl28vsdjOTPcjJ3hPQQ57rDGIeRg5uduPSLXFNT6J+oAiev+YKTcBDyB1ew85vBBlJ80XkRThMm9cXUI6L91M2vwDvzkYnaH1xCzLApcc9O0yLWVwWcfGi2u7fHmJJc3jBCcQMUPALwnrPgrcgJy8n0zxXa7xJpwJ/I48QiwNfcH7XOQ8SxxbiN8Bfbr0gavLOjZeuh2X/IP8c3AK6ZyiM4SjaJ5JZIFLDvp0mYYyuQyT5MW1Xb69xJLmVxAOR26yfSFhvXU0drzxFN/jGm/CYcBZyKPC9iSs24oqMgJq96q0iPXl0gdZuKxj6mU2MYbkSs0yrkr6/IP8c3A/csh0ILJ8APjAYjsmuOZgFT8u01Iml2GSvLi2y6eXlsTNTO8PXl8Ap0XKeoCzg7K9bbY7iux4VyIXKdRHDH8EryRc4w9FRkJ1TgLOCba1K7S8H3lM2FqDbWaNL5emLlzjs3Jp6sVXu/KK7wR85eBa4DnkYfFbgduA42g87zaJ2bQ/u+ZN2VyaenFtly8vvci91k30VKvVcPBgqGyK5t80PRWR8jxwfZuKtTpOPUzj52sGkcuj+5DzEFnGV5Cb36NswO1kepb4clkh2YVrfJaYeqmQf7tc4zsdXzkIcgXnKuBY5HaTu4F3Q+Xt4it0vmtfeQvlcmnqBdza5RpfwczLwTQ/a7gKM2emO0n+HdNFwXvSVWo9CeUgDRoHvs0hvma4jSLx5bJmsI1OcmnqpUb+7eokL3ngKwdBZrejKeNrhnUoEl95C+VyaeoF3NrlGl/DzEv490xnEJ6Z+mY70sPHjQZ8xM8m1GU86sUf6jo71GU8He2lyM5UURRFUWYFaa7mVRRFURQlhHamiqIoiuKIdqaKoiiK4sj/O+WFAG4iwC8AAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$\\displaystyle \\left[ {\\gamma}_{2,2,1}, \\  2 {\\gamma}_{2,1,1}, \\  {\\gamma}_{1,1,1} + 2 {\\gamma}_{2,0,1}, \\  2 {\\gamma}_{1,0,1}, \\  {\\gamma}_{0,0,1}\\right]$"
+      ],
+      "text/plain": [
+       "[gamma[2, 2, 1], 2⋅gamma[2, 1, 1], gamma[1, 1, 1] + 2⋅gamma[2, 0, 1], 2⋅gamma[\n",
+       "1, 0, 1], gamma[0, 0, 1]]"
+      ]
+     },
+     "execution_count": 132,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pt4 = pt3.all_coeffs()\n",
+    "pt4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 133,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAj4AAAAZCAYAAAAxBCQLAAAABHNCSVQICAgIfAhkiAAACM9JREFUeJztnXusHUUdxz/Xkoq2xYIEEY20KCCIWrRBA6m51PBswksbE6FyeERCIaWpxlK1eGjCIwEKXGMhQOBG+EM0BAjhVcBeolVeDZAAvS1tvPIoVIvIw5TSov7xm809d88+Znf27Jzd/X2Sk7l3Z2bPnN93ds5vfzszZ6DdbqMoiqIoitIEPpaS/0PgCeAd4CNgVs9bpCiKoiiKkp02sBN4E7gHOCiqUJLjcyhwB/AV4C7gcnMyJZnPA7cCW4AdwBhwHbCnxzY1EdWh3nwaOBe4G9gEbEdu0P4MnEP6TZ2ipKFjiH+yajACXAM8B5yM+DBd7JbwhkcDA8AvgKEcDW4iXwT+AuwD3AuMAkcAFwHHA0cBb3lrXXNQHerPfOAG4A1gDfAK8BngNOAW4ART5n++GqhUGh1D/JNHgxHzAlgHzAamAu93Fkq6K9rLpOtzN7t5rEJEWgScAlwMzAWuBQ4GLvPXtEahOtSfjcBJyB3h6cAy4Gzgy8CrwPcQJ0hR8qBjiH9cNRhFgjdd0aEkx2eSSXfG5J9m8p4E9o8pcylyx/XjlAbWgQOAY5FQ3G9Ceb8C/gMsAKYU/L6qw0R86KAalM8fgfuA/4aOvwncaP4e7DiuGsWjtpmIjiH+KUKDwHeZFM5weQ6+FXgECT39LCL/AHP8aST0XGWGkQ7XSigz16Sr6R6M3wPWAp8Evl1w25qiwzDpGoAfHZqiAdjr4JNgwNvVcaxJGmWlKbYZRscQ3wzTBxokOT7TTbo9Jn8tcCriec2OyB8CJgML6W54HTnYpBtj8l82aeQscwdUh4n40EE16B92A35k/n6o47hqFI/aZiI6hvinCA0+MOmnwhlxjs8AMAfxzP6ecOIdwEvAIaHjJwHzgJuAZxLqV4VlyGe8O6FMYNx3YvKD49Nj8l1ogg42GoA/HZqgAdjr4IsrgcOAB4CHQ3lN0SgPTbCNjiH+KVODMZMOhjPCjs/xyFKwp4BvIIZOW8I+CkxDJhkCfAJZbrYN+Hmo7ELgb4gntg5xrrLgUv87yJyALYhD9/0Mdd9APmecCDYMmLRXq0xsdXCxQ4APHYrQAHqrQ1ka+KyfV4cx8162r8hlqCksAn5i2rcgpoytRsuQxwrvAv9E7HVYxvb4Gq/yYmObIuziq//WaQxx1cG1fhU0uB0J3FwN/B6ZDD0Doh2fJUio7QXg1xYNGDXpoSZdBswElgJvd5T7AXA9sh/Q4Uho70HgCxbvUUT9KcDzwIWW5bMSCNkVVjPsESpXNLY6uNpBdYinLA1818/DZmBDhteWjOe/AOmXLyFbcfwrppytRoPIqpIjkfkGu4BHGV/tmka/XydR2NhmEDe7QP/33yqMIYO46eBavwoavA5cgcz5m484jjOgex+fxcAlyMDxOyRUvD+ya3McnUJtRiZgPQHcFiq3BJnYdLP5fxGy18b5iLhpuNZ/0Lx6xQaTxj1zPNCkcc8sXbHVwdUOqkM8ZWngu34evtvDcy9Glri+YN7nHwllbTU6LvT/AmSQPQq5002j36+TKGxs42oX6P/+W4UxxFUH1/pV0GAessJzLXCeKbsTouf4vItsFnQX8Dm6nzeG6RTqesSZWsjEENRk4JvIDO1OViMeZxqu9ctgjUmPpduu05AOtR3pxL3ARgdXVIdkytBAmchSxOl5DrlhS3J6IL9G05D+FBdJ6qQK10kUeWyTxS5VoYpjiKsO/aZjERoEK8PawIt0bM2TtKormNScFvrahESE5iMe1g3As6EyeyNr6beGjm8F9k05fxH1XfkssjFaXNgNxDtfjYTSLgjlXYqEBn+LzNrvZJhilgfb6OCKTx1sNIB8OgxTHQ18Y6tDGSxHJjOvQyI92yzq5NXoOsS5svmyK/s6GcZf/81iF9/UeQxx1aEsHXupQZhg48KxcEbST1YE3lHaXj8fIhP4voTcbS1PKBv2WgcijiXhWj8vVwBnAmchHTyOhcgW20PIQLwe+BZyJ7oR+fmPMIF9d0XkZSGLDq740MFWA8iuQxU18EUWHXrJmcAK5EviT8ijpDBjdLcxj0ZXIZM555D82D9MWdeJr/6b1y6+qOsY4qpDmTr2UoMwsZokOT5ZLtBRRKilwL8j8rchBg3f7exD911RFK71y2IzMjF8BTJR/ERkFvsQ4qVGhRG/imzIdH8B75+mgyt11aFKGijCTJNOQub4RPE40YNrFo2uAc5ABttNlm0r+zrx0X/z2KVKVGUMcdWhn3XM830aRZcvk+T47DCpzS/R7olsqvSHmPwPkXD0MaEyxyBzidJwre9KC/sQ5quIN2vDdOBrSOd7O6WsDWk6uOJThxbZwsi2OlRNA9+06I9dm9vmlQdbjYaQ1VlHI6vFbCnzOvHRf/PaxTct6jWGuOrgQ8cWvdEgisB3+SCckeT4BDsjnoNsmvQ60TtGDgBfR2ZhJz1vW4msq3+K8VnW+zH+uzppuNafinjRATOAWYjX+IrlOYpmDvJIcWUB57LVwdUOddOhihr4rl9lbDVahdwJn4LYJYjevE/ol55jKOs6Kbv/utoF6td/fYwhrjq41u83DTr5OGLDQcb3KZpA0vydB5DlofOQD/IR8sHCHIgYIW0C1p1ISPqXyCSqOUjoqnNn6BYSlprRg/qzTRuDdl5l/l6R0u5ech+wO+mbRNpgq0OaHVrE2xDqp0M/agDuNnStX1dsNTofWT3yGBJeD14/7SjTwv94VXb/dbULuI9B/dZ/fYwhrjq41u83DQLaSITnSWSvn5VEBGySIj7bkQ83F1nSPpVoYQ83qc3M81XmFcdMJOT2Wg/qjzC+22MdsdVhhGQ7pGkAqkMcRWkA7jZsqgZp2GpkY5+6jVc2tinCLiMp53GtX2XK6p+u9Ucsz1E2I8hk5reAvyI3HV0MtNvt8pqUztPIhk1r0gr2qL5SjA1VB3f0Wuh/VKNo1C79geoQQ785PoqiKIqiKD0jbY8eRVEURVGU2qCOj6IoiqIojUEdH0VRFEVRGsP/Af13YUhDKMOaAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$\\displaystyle \\left\\{ {\\gamma}_{0,0,1} : 0, \\  {\\gamma}_{1,0,1} : 0, \\  {\\gamma}_{1,1,1} : - 2 {\\gamma}_{2,0,1}, \\  {\\gamma}_{2,1,1} : 0, \\  {\\gamma}_{2,2,1} : 0\\right\\}$"
+      ],
+      "text/plain": [
+       "{gamma[0, 0, 1]: 0, gamma[1, 0, 1]: 0, gamma[1, 1, 1]: -2⋅gamma[2, 0, 1], gamm\n",
+       "a[2, 1, 1]: 0, gamma[2, 2, 1]: 0}"
+      ]
+     },
+     "execution_count": 133,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# To enforce results are zero for all distance, the coefficients must be zero\n",
+    "ee_soln = solve(pt4)\n",
+    "ee_soln"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### No electron-nuclei cusp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 134,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAACCAAAAAfCAYAAAA8lS7JAAAABHNCSVQICAgIfAhkiAAAF2dJREFUeJztnX2wJUV5h59dg7AuCyiooCRZMaJ8FLuwgBYIuSAQPyrCEghlSqlbksRApdBYKpJaUgsmEkUECWIiqFcwBiMELVBK5CMlAcGVgAlhkYLaG2Pc4kMMCOEzkj96pvbcuXPOzPT0TL895/dU3TrsnOnTPW/3vL+3X3p6lqxfvx4hhBBCCCGEEEIIIYQQQgghhBBCiDYsjd2AhFkF/D3wU+BpYBNwGbBXzEYNFF9bb+tR1+nABuBx4GHgamDvmmV97qc29QkhuiMlfZQfSYem40p9K4RdUtIJIcaxPHYDhPIKPdLG1k1zC21jOMWMQgyHVGJG+ZF0kEYIMRxS0QghJjE2r6AB7seJwB3AM8AJwO7ZMYBTYzVqoPjaeg3wBx71zQAXAQcBhwPPA9cDL6sotzvw7h7rE0J0yyrgsNiNqMkM8iMp4KMTM6hvhbBKSjohxDh2BNbFbsQUo7xCf7SxtU9uYQb/GE4xoxDDIpWYcQb5kRSQRggxLFLRCCEmMTavsMTYKxguBd4KvAZ4MlIb1gA/BP4Q+ELJ9wcB3wM+DJxX8v3LgEcLxyxcl0W6sDXATjibHw0817KN2wKPAcfgVoiWsQL4B+A43JMUXdcnhOiHC4ALgftiN6Qh8iP2CKUT6lshbJGqTggxymnAPPC1yO0IiYX5t/IK/dFVXgHC5RbqxnCKGYUYJinGjPIj9pBGCDFMUtQIIYqU5hW63AHhdcDZuFXmD+Mmaw/jVtidArykcP7+uBV8f013k+kbgReAQyaccwfwDeAvKd9m73zgVsonrrB44mrluiwS2tY5nwX+ivaLD8AFd0sn1AVwLq6tbRcf1K1PCNEPHwMuJr3dguRH7BFKJ9S3QtgiVZ0QYpRzgT8DXlnj3FcC/4dLko1iaT5qZf6tvEJ/dJVXgHC5hboxnGJGIYZJijGj/Ig9pBFCDJMUNUKIIqV5hS4G9RLgLOBu4KM4Ubwia8D1wL64Sdx3CuU+jnsX0ec6aFPerv2AXwF3Vpx7NrAzi7fiewNwAK79dbF0XRYJaWtwyZI9gFvaNw1wgd1dwG1jvl+De6Li+p7qE0L0x8PAvcC7YjekIfIjtgipE+pbIWyRqk4IMcrzwNdx89YqjsblEK4aOWZtPmpp/q28Qn+EzitA2NxCnRhOMaMQwyXFmFF+xBbSCCGGS4oaIUSR0rxCFwsQvgicAdwPrAYOBk7GLUZ4F7Ar7n0Q94+U2R04AvhH4KkO2gRuR4btgR8DT1Sc+wPcTf8+4EUjx1dnn3fUrNPaddVhFvfUw0yA36pDKFvnrAO+FKBdAOcAhwLH4570GVffpT3WN43M0u+YnFZmkZ3L+DJuUd1WLX9nln7sKz9SzizxxnconVDfljOLfFcfzCI7jyOETswi+/bBLLLzOL6Cm6v/ZsV5a4Gf47azz7E0H7U2/1ZeId28AoTLLdSN4RQzdsss0oA+mEV2HkdKMaP8SDmzKK8wVGaR7+qLWWTrMlLSCCFbj2NRXiH0AoQP4oy/EXgT8KOSc57CbWF3ysix9+JW3Hf53sk12WfdieflwG/gJvo5y7LPuhNyi9fVNYfhbr5zgAOBb+K2dHoB2GtMmRC2BtgNOIqFT+T4tu9c4ETgLSxcLDPKrsA7cSt7uqzvWNyWj7czPil4ZvabfzyhLdNI0/EoW/sxZLvdCmyNu8ZYhPJbQ+6nrvHRNqjWCWlEXKQR/TB0u8XWCY3jfhi63R4ENgAnTThne+Bw3LuCRxPWluajFuffyiv4ETOvANW5hZB5BVDMaB1pbT8M3W6pxIzKK3SH8grDpUnfytZ+DN1uqWhEztD7oyuGbrdFeYWQCxB2wS0seB74feCXFeePrtw/ApfE6HLrn/2zzx/WPD/fZu/IkWN3Z5+HjinzksK/LV5X1+yXfe4N3IzbwvHvgK/inkgoI4StAU4AfgHMt2zfBbj3ax4G3DPht04AHgM2dVzfg8B3cc7/IyXf75Yd3wBcMqEt00jT8Shb+zF0u/0rcbfBCuW3ht5PXeKjbVCtE9KIuEgj+mEa7BZTJzSO+2Ea7FY1jt8BvBj4p8JxS/NRi/Nv5RX8iJlXgOrcQsi8Ql6fYka7SGv7YRrsZj1mVF6hW5RXGC5N+la29mMa7GZdI0aZhv7ogmmw24Jx/GsBf/gDwDa4Lerurjh3lOW4bfE2Ak8GbE+RphPqDdnnoYVj3wYuxE1Ub8GtRlmDW5GyDvh+dq7V6+qa3Fm9Gfht6iVJ2to653Cq31dZ1b6LcAHZMbhVXjtnx59g8VMTR/RU3y1s2e50fxZzAS4ZeApOHMQWmo5H2dqPodvtLuD9uEV7Mdofym8NvZ+6xEfboFonpBFxkUb0wzTYLaZOaBz3wzTY7U7cnH5X4Kcl36/FzWu/WzhuZT5qdf6tvIIfMfMKUJ1bCJlXAMWM1pHW9sM02M1yzKi8QvcorzBcmvStbO3HNNjNskYUmYb+6IJpsNuCvELIHRCOyT4va1ju1bh39G0O2JYiS4F9cU8N3FWzzGPA07gt/EY5FvgU7nUTd+EmtB/BDZ7RYMDqdXVN7qzeT/1Aqq2tcw6k+smCqvadDKwAbsD1Xf73oZJz30j1YptQ9T2Du7Y9CsffiXsa6fPYSRZZwmc8ytZ+DNludwPbAXtGqj+k3xpyP3WJjy+Bap2QRsRFGtEfQ7dbTJ3QOO6Podstn0e9seS7bYC3Atfi5m05luajVuffyiv4ETOvANW5hZDxOShmtI60tj+GbjfLMaPyCt2jvMJwadq3srUfQ7ebZY0oY+j90RVDt9uCvEJxAcI8bjV43b+vZOW2BXbPjt3esEE7Zp+/mHCOb7tydscJ7b00e2rgUWCnwrFngE8C++CeRngpbvX8X7AwGWP5uibV/6Xsu5tKvpur+L3lWZsemnDu2cB1Jcfb2BrgFTgH/T8t27dkzN/6wnk7Ze2Z1L8h6wPXzytwq4fAvc/yfOAR4M8ntCMl5gk3JuvYH8rH5NBtPU/Yez9nqHbL7/Pfqnn+PP2O4yZ+BIbbTznz2NC2Kp2QRjRnHmlEH8wjjWhKE52YR+O4D+bROG5KPo96bcl3R+Hm/FcVjluaj1qefyuvkE5eAapzC6FjOMWM4ZlHWtsH80hrm2I5ZlReYSHz2NA2aUR45rHRt7K1n04M2W6WNQI0jjWO67Egr1B8BcMDlE/AxvGz7PPl2efjwP82bNBT2ec2E87xbVeO73aCy9jSvqZYvq6c84EdCsdWA0cDX2bx+w6rnoZYhVvU8i3GbxHyCdyTFUXa2Bpgl+zz8Qnn1GlfXV7dc32w5X07e+K2RT0deA1wEgsD0dNxT3m8HpdsuS071uTVKKcAH8bZ9T9w26bcXLNsm/pDjsm69i8bk6nY+tCs7Jqs/PHAFTXKhb73c1KxW9Py+X3+qpq/HWMcN6FuP0G/di7iO06saFuVTsTSCF+/MYo0wmHd1qlqRGy7+ZRvohOpjWOIqwWpjmOIazef8vk43qXku7XAs7ixNoql+ajl+bfyCguxnFeA6txC6BjOaszYds7WVs+nKWaMbetUtTa23WB4MWMTUontlVdoRl/9OhSNAP++TcXWbcp3oROp2A2GpxHTmB+DtMcxRM4rFBcgvKVBxaPkq+SX4bYHLJsIjuOh7HPHCef4tisnn1Df0aDMUtzA2uRZp9XrGuX8kmOzuJtnDvjnhr+Xb9UyaReMsqcI2toa3BM54LZdHEed9p2Nu6GPqqhvec/1wULH9ABu28jb2LLiKmcG936vDbgVrWcB12flHq1RzwnAZ3DO5V9wW3Vdm5X/SY3ybeoPOSbr2B/Kx2Qqtl4O/Chr15U1zs8Jfe/npGK3puXz+3x5yXdl9D2Om/gRqN9Pfdu5yAx+48SKtlXpRCyN8PUbOdKIdGydqkbEtptP+SY6kdo4jq0FqY7j2HYLOY5fBPwucCOLNc3SfNTq/Ft5hbTyClCdWwgdw1mNGWdoN2drq+dt6k9Na2eIa+tUtXaGuHYbYsyo+ecWrGibVY2I5XdyZrChEeDft6nYuk35LnQiFbsNUSOmMT8GaY/j6HmF4gIEXx7CrfRYiROAGyacu5SFK2k2Aw/jVqx1xZrss8mK/tfjBKzuCt0iVq+rS3JnNa49O+BW8KzG3Tg5bW0NbnsTst/xbR+Mf5KiSF7PCxPOCVkfLHRMR+Du31NK2vA7hX+/B3fjHwxcXaOeD+Kc58XZv08F3oZzMKfXKN+2/lDUsf+4MZmKra/N/qyQit2als81a5J/6YrQfgTq91Pfdi6Sii8Z50eqdCKWRrT1G9PSr9BeI2LbOlWNiG03n/KxdKKPcRxbC1Idx7Ht5lN+nG4divuf38XXL4Ct+ajV+bfyCs2JmVeA6txC6BjOaszYNmZr67+nKWaMbetUtTa23YYWM4Lmn12ivELY8lb6Ffz7NhVbp6oRsa97aBoRexxPa14htt1a5xWWNmzwJPKVIBcBbxhT8duAywvHXwC+h3unUd33azdhKbAvTmibTETflH3e5Fmv1evqkv1wW3P++5jvVwPPARsLx9vaGrbswrHdhHOq2gduJdcvDdYHcD+uv48H3gF8DrizRrkVuPFSZwX4i3EJqOL7fK4DDqrZzjb1h6SO/ceNyVRtHZsU7OZTfvvs0+eduG0J7UegXj/FsHMVVn3JOD9SpRNWNKIJ09SvEF4jmiCN8COW74qlE12PY4taEJsU7OZbPter4jg+FpcM+2bhuLX5qNX5t/IKzYmZV4D+Y7hUYsZYMVvs+q3nFYZICnYbYswImn92ifIK3RLTb/r2baq2jk0KdhuiRig/FpYU7BYkrxBqBwSAC4B9gPfiBut1wH24gfnrwJuBXYGvlpS9Evg93Oq1+wO2CWAP3HYPTwJ/M+acR4CPFo4dhRsExURLEyxeV1dsjVux8284h1XGapyTKn4fwtabs89xAVmd9o1byVXGgz3XR/Y7m3CJp4eAM2qUAbc46C7cNi5V7ITbZvXBwvEHcauxfGhSfyjq2B/Gj8lUbR2bFOzmUz6/zzeP+b4ruvAjUK+fYti5Cqu+ZJwfmaQTljSiCdPUrxBeI5ogjfAjlu+KoRN9jGOLWhCbFOzWdhz/rHD8GODWkt+zNh8Fm/Nv5RWaETuvAJNzC13EcKnEjDFittj1p5BXGCIp2G2IMaPmn92hvEL3xPKbbfo2VVvHJgW7DVEjlB8LSwp2C5JXCLkA4QXgJNzk+I+AA4EjgSdwN833gW8B15SUvRLX8BOBzwZsE2zZTnB51r4yvlP49/a4RMs1wH+1qNvadXXJ3sBWTH5v5GoWP1URytYPAY8DL23ZvrKVXGVsxiVpduipvpx7cY7pNMrfu1PkHNy2qYfQbIv24nYvS0qO1cG3/rbUsT+Uj8mc1GxthVTs1qR8vgI1dMK3iq78CNTvpz7tPAnLvmScH5mkE1Y0wpdp6FcIqxG+TLtG+NK374qhE32OYytaYIVU7Na0fD6PGh3HB+AeIjiv5Hxr81GwN/9WXqE5sfMKMDm30EUMl0LMGCtmi11/SnmFoZGK3YYWM2r+2Q3KK3RLTL/Zpm8hPVtbIRW7DU0jYo/jac0rtCVqXiHkAoScb2d/TXgW+Azwcdz2fyG3m7g0+2vCicA2wLkt67Z2XXWYy/6acgfV76dZBVxWOBbK1gAbgL3GfFenfeNWck2qb48e6wN3A/8K+HqNc88F3g0cRn3hegQXrO1cOP4KFq926qL+MuZoPibr2B/Kx2ROSrYOwRx+934R63bzKb8nbsJ3T802ljFHN+PYx49AdT/FsPM4QviSOfrVtpxxOmFBI3yw1q+Qhkb4II3wI5bvaqsTc9gcx5a0IARz9DOOY9vNt3w+j7p95Nja7POqkvOtzUfB3vxbeYXmWMgrwPjcQlcxnOWYMVTM5ss0xYyxbR2COdLIK7RliDGj5p/VzKG8gjViagS079uUbB2KOdrrhHW7DVEjlB9byBz2x7GJvMLSGhX1xXnAT4CzIrdjGXA67imDmwP8npXris1WOCc6ut1TaFvfgAusfJm0kquMm3AJoL7qW4Jz9j+m+l1AF7AlAGsiWs/ihOfIwvEjcVuv1sW3/j4pG5M5KdnaEinYzaf8vrh37z5fv5m90dSPQL1+imHnMqz7kkl+BNrpRJca4cu09CuE0whfpl0jfInlu6zqRNtxbEULLJGC3dqM440s3PJzLW78bKpRrxWszL+VV+iGPvIK0C634BOfW40ZY8dsseuvQ+y8whBJwW5DixlB88+YTFteIRTW+xXi5xWGSAp2G5pGxB7H05pXaIuJvEIXOyD48jTwHpxo5O8gjMFK4POEWbELdq4rNnsCL2Zh0LOSsLa+HPdUyGuBBzzKT1rJNa6+M4FXsfhdqV3U9zpgW6qfeLkIF4AdAzzKllVKT2R/VXw6a9cPgFuA9+Gu8W9rtrNt/X1RNiZzUrH1tritenJW4iYXj+ISlH2Tit2alt8Xd69bpKkfgfr91Ledi6TgSyb5EWinE11pRFu/MQ39CmE0IratU9WI2HbzKW9VJ0KM49hakOo4jm03n/L74XRrlHG7vVnGyvx7JcordEEfeQVol1vwic8txoxtY7a2/nuaYsbYtk5Va2PbbUgxI2j+GZNpzCtII9KxdaoaEfu6h6QRFsbxtOYVYtutdV7B0g4I4Fb4nEncyfRGYD0wH/A3LVxXbFYD/w38fORYaFtvAr4BHOtRtmq1aRn3ATf2WF++2rXKMZ0MrMA9tbF55O9DI+fM4t7VsrKk/NeADwDrcMJyCPB24D9rlq9TvwXKxmROKrbeP2tj3s5zsv+O9WRUKnarUz5nFbAdcEXFNcXAx49A/X7qw86TyqfgSyb5EfDXiS41oo7fmGW6+xXCaERsW6eqEbHt1kQjwLZOhBjHsbUg1XEc225Nx/EuwBrgCxOvKh0szL+VV+iGPvIK4J9b8I3PLcaMbedsbfV8mmLG2LZOVWtj221IMaPmn3GZxryCNCIdW6eqEbHtNiSNsDCOpzWvENturfMKS9avXz/mXCGCciFudYzP/6xvwh64G2OfhuVW4W6inRgf8JVxGPBJ4ICe6gvFmcBxWTt8tvVpW94CfY1J2doPK3Y7D7eq8GMtfqMrYvsRsNNPsajjR3x0InbfTnu/gjTCOpbsZlknNI5tY8lupwG74Z5oEMIyffk18MsttInhFDOmibTWNpbsZjlmlC+Ji/IK3ZS3gDTCNpbsZlkjNI5tY8lui/IK1nZAEMNjGW6lznHAtT3UtxG4HZhpWK5qtek4bsI9aXFgT/WF4u3An+LvVNqWj0nfY3Kabd0GC3ZbARwMfKrFb3RJbD8CNvopBk38iI9OxO7bae1XkEakghW7WdUJjeM0sGK3rXDJpHUtf0eILunbr4FfbqFNDKeYMS2ktWlgxW5WY8Yc+ZI4KK/QbfmYSCPSwIrdrGqExnEaWLFbaV5BOyCIrlkH/AlwNXAq8FwPdW4HXIJ7F9SzNcu0Wcn1cuCLwFrq36h9PrkhFhJjTIo0OR+4Erg5dkPGID8Sj6Z+pKlOqG/jIY0QTbCqExrHoglnAPfgxrIQVonl15rmFtrGcIoZ00FaK5pgNWbMkS+Jg/IKw0UaIZpgVSM0jkUTSvMKWoAghspK4HBcYDaJZcBewDW4m+Riz/r2x71X69Ke6hNCdMs+uJXll8RuSAnyI2lSRyfUt0Kkg2WdEKIuK4ETgE9EbocQlllJdW4hZAynmFGIYWE5ZpQvSQ9phBDDwrJGCFGXlYzJK2gBghgy2wBPV5wTciXX1sAzPdYnhOiOOvdzLORH0qVqXKlvhUgHyzohRF2WAU/FboQQCVCVWwgdwylmFGI4WI4Z5UvSRBohxHCwrBFC1GVsXkELEIQQQgghhBBCCCGEEEIIIYQQQgjRmqWxGyCEEEIIIYQQQgghhBBCCCGEEEKI9NECBCGEEEIIIYQQQgghhBBCCCGEEEK0RgsQhBBCCCGEEEIIIYQQQgghhBBCCNGa/wePkksqAriw2gAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$\\displaystyle - \\frac{C \\left(- L\\right)^{C} \\left(- L + r_{j}\\right)^{C} \\left(r_{j}^{2} \\left(r_{j}^{2} {\\gamma}_{2,0,2} + r_{j} {\\gamma}_{2,0,1} + {\\gamma}_{2,0,0}\\right) + r_{j}^{2} {\\gamma}_{0,0,2} + r_{j} \\left(r_{j}^{2} {\\gamma}_{1,0,2} + r_{j} {\\gamma}_{1,0,1} + {\\gamma}_{1,0,0}\\right) + r_{j} {\\gamma}_{0,0,1} + {\\gamma}_{0,0,0}\\right)}{L} + \\left(- L\\right)^{C} \\left(- L + r_{j}\\right)^{C} \\left(r_{j}^{2} \\left(r_{j}^{2} {\\gamma}_{2,1,2} + r_{j} {\\gamma}_{2,1,1} + {\\gamma}_{2,1,0}\\right) + r_{j}^{2} {\\gamma}_{1,0,2} + r_{j} \\left(r_{j}^{2} {\\gamma}_{1,1,2} + r_{j} {\\gamma}_{1,1,1} + {\\gamma}_{1,1,0}\\right) + r_{j} {\\gamma}_{1,0,1} + {\\gamma}_{1,0,0}\\right)$"
+      ],
+      "text/plain": [
+       "        C           C ⎛   2 ⎛   2                                             \n",
+       "  C⋅(-L) ⋅(-L + r_j) ⋅⎝r_j ⋅⎝r_j ⋅gamma[2, 0, 2] + r_j⋅gamma[2, 0, 1] + gamma[\n",
+       "- ────────────────────────────────────────────────────────────────────────────\n",
+       "                                                                              \n",
+       "\n",
+       "        ⎞      2                      ⎛   2                                   \n",
+       "2, 0, 0]⎠ + r_j ⋅gamma[0, 0, 2] + r_j⋅⎝r_j ⋅gamma[1, 0, 2] + r_j⋅gamma[1, 0, 1\n",
+       "──────────────────────────────────────────────────────────────────────────────\n",
+       "                             L                                                \n",
+       "\n",
+       "                  ⎞                                      ⎞                    \n",
+       "] + gamma[1, 0, 0]⎠ + r_j⋅gamma[0, 0, 1] + gamma[0, 0, 0]⎠       C           C\n",
+       "────────────────────────────────────────────────────────── + (-L) ⋅(-L + r_j) \n",
+       "                                                                              \n",
+       "\n",
+       "                                                                              \n",
+       " ⎛   2 ⎛   2                                                     ⎞      2     \n",
+       "⋅⎝r_j ⋅⎝r_j ⋅gamma[2, 1, 2] + r_j⋅gamma[2, 1, 1] + gamma[2, 1, 0]⎠ + r_j ⋅gamm\n",
+       "                                                                              \n",
+       "\n",
+       "                                                                              \n",
+       "                 ⎛   2                                                     ⎞  \n",
+       "a[1, 0, 2] + r_j⋅⎝r_j ⋅gamma[1, 1, 2] + r_j⋅gamma[1, 1, 1] + gamma[1, 1, 0]⎠ +\n",
+       "                                                                              \n",
+       "\n",
+       "                                     \n",
+       "                                    ⎞\n",
+       " r_j⋅gamma[1, 0, 1] + gamma[1, 0, 0]⎠\n",
+       "                                     "
+      ]
+     },
+     "execution_count": 134,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# First derivative of electron-nuclei distance should be zero at r_i = 0\n",
+    "ftmp_en = diff(ftmp, ri).subs(ri,0).subs(rij,rj)\n",
+    "ftmp_en"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 135,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAB88AAAAfCAYAAABphIzzAAAABHNCSVQICAgIfAhkiAAAFuNJREFUeJztnXuwJVV1h7+ZCDrO8FJUUIwjQZBHmIEZEUEmFwVMpEqRQIgI1C0NKsRC4gMkGVIXJL6QQBCJ4muAQEChxCJAhQhYIM8BeQQZIVDcIDI1gJOATMSBZPLH6mbO9O3u06/de+9zfl/VqXNv9+7ufdav1+q9uvfePWtqagohhBBCCCGEEEIIIYQQQgghhBBinJntuwItWQBcBDwOPA88ClwI7NzhMZYAVwJPAOuAQzrct8inqa7zHNcrj7/GzotzPBxb1OcvgfuAZ5PPrcCBXmskqiDd4uUkYDmm21PY9XQXrzUSVZF2cSLdhBBCdEmbe0bKlf2g3Mk/0sAvag/7Rxr4RfYXQohqeczctjsIlaOAu4DfAYcB2yfLAI7r8DhzgXuBT3S4T1FMU10XAYe7rdoM9gSOxpIiEQePA5/DzpfFwPXAFcCuPislhiLd4mUCOBfYC3gX8CLwY+BVHuskqjGBtIuRCaSbEEKIbtgeOKLhtsqV/aHcyT/SwC8TqD3smwmkgU8mkP2FEGIBsO+QMq8GlhatnFUwbfsFwB8DbwbWNKxcGxYBdwJ/AXwnZ/1ewI3AZ4Ezc9a/CljtoF7rgEOBy4aU822/UHGl65aYzd8PvNBJTYezGfAz7IbA3wL3ow4WsbIa65X5Td8VEbWQbnEyD3gGOAjr/SziQdrFiXQTQgjRhE2Af8Zm3nu+5rbKlcNDuZN/pIE/1B72jzTwi+wvhBhXzsZmwXqopMyJwDRwaXZF3sjzxVjv4i/h5sHv9dhD6H1KytyF9co8jfypuM8CbiH/ASu4eXBelRDsFyqudP068HeUPzh/C/DFpA5PJWWfwnreHQu8ckjds5yHdaK4vuZ2oj5da5fye8AHsXPxlvbVFBmkW7y40g7sRuxs/F6nRxWXuoG0c4l8Ll5c+51oh/QJH2nUD03uIZyB5ed1H5yDcuWQUO7kH2ngH7WH/SMN/CL7CyHGlc8D36J8BvYzgL8CXpddkTfy/FpgD2Br4LedVHHgeMB/YUF7M+C5krJ7ALcDfwN8YWD5W4EVwJ+T0xvAMVVGnodiv1DpWtd9sIfnRdNfzQJOwXqQbIwlK/dhPe7eBByAjWj/KdVvJhwNfBx4B7AW+AnqTe8CF9oB/CH2zrFXAL8BPgRc3VmthXSLF1faDXIpNgXoYuB/W9ZXGH3oBtLOBfK5eOnL70QzpE/4SKP+aHIPYRFwPs3ej6pcOQyUO/lHGoSD2sP+kQZ+kf2FEOPMN7HZri8qKfNpYCfgI4MLs0/ctwf2A75P9w9+wXqWbwY8yPCk7Q7gF8DHsJ6aKQuT77tqHnsKe/hd9pmouc8sIdmvCpN087vr0LWuS4Hvlaz/LnAy8HByjL2BY7D3T30Q2CbZx8MVj7cD9tD/Q9jNAJHPJO3Pra61S3kw2d+ewDewKf+b3BgaVSZpp51088Mk4fpcyunAEqwTmhK29UwSps8NIu1mMol8LlYmCV+7cWeS8OPiODOJfCgmmtxDWIq1teuiXLkak7i/D6PcqZxJpIFPJunvXqTaw/lMIg18M0k/Gsj++UzS/zORcWUS2boPJpGdizgfOBXYqKTMP2F56JsGF2Yfnn8Y65nsakT3ouS76gPSS4Dfxx5Ip8xJvus+PD4H2HHI546a+8wSmv1csy/mlKdjI8p/hE0Bsw7YuWS7rnTdFhuV8MOC9Z/CAscKLGG5N6fMb7Ep348dWFb2u/bD3rF+P/Bi8vmjZPsXgZcP7OdgbOrB28k43gCnJPv9aNGPHFNcaJeek2uxG3F3Yu8cuwc4fmAf0q05PnUDadcGl9qBTYFzFPBuZt4Il27Nca0bSDtX+PQ5kHZt6MPvpE9z+tAHpFEbmmgkezen7j2EbYD3AT8oWK9c2T/Kef1S9XohDdyh9rB/dB/AL/IB/yi36wflaP0w6na7BctDDi4pswpYzpCR5/thvZBu67J2AyxOvu+sWP7m5Hv/gWX3J99LCrYpei/a09iI57LP/1SsVxGh2c81uyffuwA3Af+HTYNwMWbPIrrS9TBsCrrpnHVbYzdcXgT+DJsmq4zBmQLKftcl2PRbCwc+dybLF7JhD/tVwL9hwf2EnGNumyxfDnx7SP3GCVfaFZ2Ts7Gp1FKkWzN86wbSrimutTsbOAJr9D6Qsz/p1ow+fE7aucG3z4G0a0pf1zrp04w+2yLSqBlNNZK9m1P3HsJh2PT5jxasV67sH+W8fml6H0wadIfaw/7RfQC/yAf8o9yuH5Sj9cM42O1n2MjyWmVeNvD3XCyhWQGs6bRq66mbuC1Pvpdkll2NjSR/JfYgdh3Wo/qj2BRjt7au6XrmAdsN/D8fs9Nq4LGB5SHazzVpAHsn1qO8aqeBrnR9F3B3wTGOxxKT77H+wXxVhv2uX2f+X4OdD9nj3Ax8ICm/mJmcjb3j71gs+AvDpXZfAq4Cfom99+9wbDqTAwfKSLdm+NYNpF1TXGp3LpawHYTFya2S5c+xfqYR6dYMl7qBtHOJb58DadcU136XIn2a0Zc+II2a0lQj2bs5de8h7Edxjg3KlUNAOa9fqlwvpIFb1B72j+4D+EU+4B/ldv2gHK0fxsFu9wCfxDozFv2Gu7F8dRvgcdhw5PkbsHdQr3RUwdnAbtjI7HsqbvMM8Dw2xfcgBwNfxaZ8uwd78HoCJnRZoteExck+0/2envx9aqZciPZzTRrAPkm90fZd6boHxb3nDkq+L6xRr5SmvyuP32F13DGz/H1Y4nQe4XSGCAWX2m2FvcPiQeA64G3AnwDXZMpJt/qEoBtIuya41O4Y7IbRddj1Mf18JlNOutXH9XVO2rkjBJ8DadeEPtuX0qc+fbf/pVF92mgke9enyT2Et1PesUG5sn+U8/qlig9IA7eoPewf3Qfwi3zAP8rt+kE5Wn+Mut3uBzYFdiopkz5nfHu6YNbU1FT69zuw+d+/j03VlWWa4jnv87gI6+WU8lZsVPbPsakWqvIr4HVsOEo+REK1X9Pjn4+9i66IucCz2HT4W5PfY+OL2MjxA3LWtdX1tdiUEqcBJ2fWzcOmAFyX/F1nOv4qv6suFwBHAm/Eeq3MwXTcBNgem3o+Zqbp7twKSbtR1w260y4k3WD0tZtGPhcr08jnYmSa0fQ5kHZZfGqX124edX0gnrhYlNeMukbThOFDKbL3hmTvGWSpew9hS+Ap7J2GUznrdR2qzzT934epw6jbH7rVQD5Qn2nC9gGQBlkUh7pnGsUhn0wTxjORUbcz+DnXx9HW03R7TqeMst32B67FRthfUVBmO+A/gBOBr8CGDy7T94ll3yGb8gg2WrgqT2T+bzrl+Bw2fB9dqIRqv5SzgM0zyxYC78ccaDqzbljP9AVYT/arKA5eX8Z6uefRVtetk+9nc9a9ZmBd3ZsyVX5XXdJ3cOyEBZ6TgDcDH2HDoHMSNvp+B6y3z23JsjpTGh4LfBazz8+xqSZuqrht0+N3eW6FpF1V3ZZgNl+E2f1Q4LKax/KhG3SnXUi6QTw+1/TcGXefg3Z2b7u9fG4mscRL+dxMqmjnO1a22UdM2uW1m2OJi218O5a4WJTXxBL/mm4fig+lxOITTbdve88gS917CG9IvvNybIi73d7WB0PIlSHenNeX/aFbDcbZB0JoR4M/Dbq4jkP89+xgfONQCO1dGO84BP7bs+A+t/OdN8R2rvu09aic0ymxnKNNtk/zm9dXKJM+d9zg4fmTyferCzZ+d8mOq5AmbnfV2GY2diI82vLYfRCi/QY5K2fZJOZUy4Cf1NxfOm3G7SVl/rtgeRe6zku+n8lZtyb5noNNpV/0AD+PKr+rbER9HoOB5xFsKvrbsHf9DTKBvZdmOTALezXAj5PtVlc4zmHAP2DB46fYND3XJNs/VmH7psfv8twKSbuqus0F7k2WX161sgP40g260861buBGuwn8+lzTc2fcfa6t3eVzhg+f8x0v5XMzqaLdBH5jZZt9xKRdXrs5lrjYxrdjiYtFeU0s8S92H0qJxSeabt/2nkGWuvcQ5ibfeTk2xJ0rt/XBpsf3cR8mxDacL/tDtxrEnLv60jB0H4BqGrS1H4zGPTsY3zgUQnsXxvtaHEJ7Ftzndr7zhpjOdfBr61E5p1NiOUebbJ/mN3ML1ueWGXx4vhKbomuHChVswqLku87I6R2wYBzKO77LCNF+LkkDWFF9Nsd6pCzEnGmQLnRdl3zPyln3JNbDZj52Yb+uZD+z2bD30rDfBeUj6vMYDDz7YX53LOt/Q8p7Mv8fiTnt3sCVFY7zKSxAfiv5/zjsvVrHYD2FhtH2+F0QknZVdbuG/HdvV0W6GcNimwvtfPtc23OnC2L0ubZ2l88ZPnzOd7yUz82kina+Y2VX+2iLS+2K2s2xxMVR962yvCaW+Be7D6XE4hMh2Bvq30NIc+usPVNizpXb+mAI7T+IN+cdJ/tDmLmrbw27wlcc6uL3j0IeCuMbh8bdB8B/HAqlfeU6t/Ntp5jOdd+29q1V18RyjjbZPs0t854lkln30u+dPbByHXAj9p6r7SpUsg6zgd2wwF3ngemeyfcNHdfHBSHazyW7A2uBfy9YvxB4AXvHWpYudE1HLmxasD7tgXMu9q63LLMwp7oks3zY7wLr0fSbatUE4GFMu0OBA4F/BO6usN0mmPZVeu9tjN0cuTaz/Fpgr8o1bX78LglFu6a61UG6VdMN+tHOt8/5Iiafa2t3+VxYPlcH+Vw4bZS+Y2VI2rvSrqjdHGtc9EXf+kAc8S8kjZtqlBKDT4Ri7yb3EIbl2KFch8Bf+8v38WPMeV0Qsv0hvNx1lAgpDtVhlPJQxSG/hOQDfZ6DobSvwG1u15aQ7NSWKue6T1u3JUStYjhHm26/WfK9pqTMptkyL8sUuBz4U6wn0cPDalqDHbHh7muArxWUeRr4XGbZAZhgP+qwLi4JzX6ueDnWA+U+LIjlsRALXHnru9B1ZfJdlNifDewKfBgLstcCD2EB9Y3AO4FtgIsHtqnyu8pGnhSxFpuifjtsxMXJFbc7C7vRcVuFslti0x+uyixfhfUUakKd43dJKNo11a0O0m24btCfdr59zhcx+Vxbu8vnwvK5Osjnwmmj9B0rQ9LelXZF7eZY46Iv+tYH4oh/IWncRKNBYvCJUOzd5B5CWue8HDuk6xD4a3/5PH6sOa8LQrU/hJm7jgqhxaE6jEoeqjjkl9B8oM9zMJT2levcri2h2KktVa+5Pm3dlhC1iuEcbbp9mt+srFDmiXRB3sPzVcBRwNeH1bQG6XRhc7EXzOfxr5n/NwMOAv4F+GWHdXFJSPZzyS7ARpS/O20h+T3cu9L1SeBZYIuC9eswW10OHA3sAewPPIc5ya3AVUk9Uqr+rqKRJ2X8Ags8J1L8zsRBTgeWAPtQb6qd7DQas3KWVaHp8bsgJO3q6tYU6VZOH9r59jmfxOhzbe0unytnHOKlT0LyOainnc9YGYL2LrUrGhkaW1z0iQ99IJ74F4LGTTTKEotP+LZ3k3sIK7GH7ZvnlA3lOgR+218+j++7/R0KIdsfws5dYyekONSU2PNQxSG/hOQDvs5B3+2rvnK7tvi2U1vqXHN927otoWkVyzlad/t05HnZgOctsmWyD8/XYi9b/wI2xVdXw/IvSD51OAp4BXBGR3Xog5DsV4Vlyacud1H+fgCABcCFOcu71HU5sPOQMlcnnypU+V1lI0/K2AJ7t8IPKpQ9AzgC2JfqMxg8jTVWtsosfy0ze+K4OH6WZTQ7twYJQbs6ujUhNN2gvXZd6wbutfPtc12wjPHwubZ2l8+F4XNNkM/5b6P4ipVda7+M8LQrajdDXHGxK5YRVlws0wfCj3+x+1CW0H0iFJ9qeg9hOTZqPUsI1yHorv3VFJ+5cqw5b5f4bH+H0o727QNdsIywfADCv5YPojg0GizDTRwa1WtxKO1Z17ldW0Jphw6yDHfXXJ+2bkso53SW0M/RptvvhHUSfqCkTPqc8fZ0weycQmcCjwGnDqupQ+ZgL3e/HLjJYz2aEIL9fLMRdkJmp4fpWtfrsEZBnwwbeZLHLCyYP0j5exXApjJMGyBlzpxlLXZh2T+zfH/glhr7aXr8GKirXR3dmiLdquFSO98+N8q40K2t3eVz1RjleDnKuGyj+IyVo659UbsZ4oqLo0qZPhBH/BsljWPwidjtfQM2EKAJoebKXeH7+FUIsQ3XFTHYH8LMXccJ13GoKeOUh45yHIqBUb0Wx9K+apvbtSUWO3WBb1u3JUStYjhHm26/G3Aj8OKQMisYmNo9O/Ic4HngSCwIpu/I6pv5wHl001uib0Kwn292AjZm5sV6Pt3qegk2yv8PgEc62ucwho08yeMtwDyGz0RwLtYAOQhYzfoeNM8ln2H8fVK3O4CbgY8Brwe+UbGebY8fOnW1q6rbPGw6k5T5WGN1NdaRZhjSbTiutPPtc23PndBxpVtbu8vnhjOq8VI+N5Mq2vmOlV3tI1SK2s0QT1wcZd8q0wfiiX+j4kOx+ETM9r4EOAWr7xNDymYJOVdu64OxtP9CbcONi/0h3NzVt4Z94SoOdfH7xyUPHdU4NO4+AP7jUAztqy5yO992iuVcD8HWvrXqmljO0Sbb74blOGXsjuVCL5E38hzsKfwp+HvwuwKYAqY9Hb8tvu3nm4XAr4BfZ5Z3reujwBXAwR3tbxjDRp4UkfbcHxZ4jgE2wUbUrxz4fCZZP4m9u2F+wfaXAscDS7ELxz7Ae4H/HChTto9hx4+ZJtpV1W1xUiYtd3ry9+DsE5MU2126leNSuyq2m8SddlXOnVhxqVtbu8vnyhnleCmfm0kV7XzHyqr7iJWidjPEExdH2bfK9IF44t+o+FAsPhGzvR8Crqd+ju07V4b2caps+xjafyG34cbB/hB27tqHhr5xGYfa2g+GXxuGbR+DH4xyHBp3HwD/cSiG9lUXuZ3vvCGGcx3CsPWondOxnKN17bYA2BS4rPgnsTWwCPjO4MJZU1NTJdsI0YhzsN4efTzU3hFzmF17ONYCzCG3pPgGmktOAQ5J6lE2xYTrfcRI7NqNq24g7WJFusWLtIsT6RYvfbWbpVEz+sxrpFG/yN7F7At8BXhbjW18X4dAmvrWYNztD9LAN7K/f6SBX3zbH6SBcrv+kK3DJiS7nYmNiv98SZkTgW2xUewvUTTyXIgmzMF6nhwCXNPTMVcAtwMTPRxr2MgT17wX+ATtAkYX+4iR2LUbV91A2sWKdIsXaRcn0i0++m43S6N6+MhrpFG/yN7F3IDNFrdHjW18X4dAmvrWYNztD9LAN7K/f6SBX3zbH8ZXA+V2/SFbx0EodtsE2Bv4akmZjbBOGEuzKzTyXHTJUuDjwJXAccALPR13U+Db2HtX1jo8Tp8jT0S3SLt4kXZxIt3iRdrFiXSLD1/tZlEN6SPGndcA3wU+QLWbVroO+Uca+Eca+EX294808Ivs7w/lDv0hW4s6nAVcDtxUUuZk4IGk3AZo5LnoktOAbbB3oPQZuJ4FTsAenrvAx8gT0Q3SLl6kXZxIt3iRdnEi3eLFV7tZVEP6iHHnKWy6xMOHlNN1yD/SwD/SwC+yv3+kgV9kf/8od+gP2VpUZVfgfsofnM/HBuPOeHAOenguRodp4GJH+/40cAXwQ2CZo2MIN0i7eJF2cSLd4kXaxYl0E0II4Yo7gUuHlNF1yD/SwD/SwC+yv3+kgV9kfyGEmMmD2GzVZawCvly0UtO2CyGEEEIIIYQQQgghhBBCCCGEGHs08lwIIYQQQgghhBBCCCGEEEIIIcTYo4fnQgghhBBCCCGEEEIIIYQQQgghxh49PBdCCCGEEEIIIYQQQgghhBBCCDH2/D9+nILF34tWiQAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$\\displaystyle \\left(- L\\right)^{C - 1} \\left(- L + r_{j}\\right)^{C} \\left(C r_{j}^{4} {\\gamma}_{2,0,2} + C r_{j}^{3} {\\gamma}_{1,0,2} + C r_{j}^{3} {\\gamma}_{2,0,1} + C r_{j}^{2} {\\gamma}_{0,0,2} + C r_{j}^{2} {\\gamma}_{1,0,1} + C r_{j}^{2} {\\gamma}_{2,0,0} + C r_{j} {\\gamma}_{0,0,1} + C r_{j} {\\gamma}_{1,0,0} + C {\\gamma}_{0,0,0} - L \\left(r_{j}^{4} {\\gamma}_{2,1,2} + r_{j}^{3} {\\gamma}_{1,1,2} + r_{j}^{3} {\\gamma}_{2,1,1} + r_{j}^{2} {\\gamma}_{1,0,2} + r_{j}^{2} {\\gamma}_{1,1,1} + r_{j}^{2} {\\gamma}_{2,1,0} + r_{j} {\\gamma}_{1,0,1} + r_{j} {\\gamma}_{1,1,0} + {\\gamma}_{1,0,0}\\right)\\right)$"
+      ],
+      "text/plain": [
+       "    C - 1           C ⎛     4                       3                       3 \n",
+       "(-L)     ⋅(-L + r_j) ⋅⎝C⋅r_j ⋅gamma[2, 0, 2] + C⋅r_j ⋅gamma[1, 0, 2] + C⋅r_j ⋅\n",
+       "\n",
+       "                      2                       2                       2       \n",
+       "gamma[2, 0, 1] + C⋅r_j ⋅gamma[0, 0, 2] + C⋅r_j ⋅gamma[1, 0, 1] + C⋅r_j ⋅gamma[\n",
+       "\n",
+       "                                                                              \n",
+       "2, 0, 0] + C⋅r_j⋅gamma[0, 0, 1] + C⋅r_j⋅gamma[1, 0, 0] + C⋅gamma[0, 0, 0] - L⋅\n",
+       "\n",
+       "⎛   4                     3                     3                     2       \n",
+       "⎝r_j ⋅gamma[2, 1, 2] + r_j ⋅gamma[1, 1, 2] + r_j ⋅gamma[2, 1, 1] + r_j ⋅gamma[\n",
+       "\n",
+       "              2                     2                                         \n",
+       "1, 0, 2] + r_j ⋅gamma[1, 1, 1] + r_j ⋅gamma[2, 1, 0] + r_j⋅gamma[1, 0, 1] + r_\n",
+       "\n",
+       "                                 ⎞⎞\n",
+       "j⋅gamma[1, 1, 0] + gamma[1, 0, 0]⎠⎠"
+      ]
+     },
+     "execution_count": 135,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "simplify(expand(ftmp_en))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 136,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABxAAAAAfCAYAAADHnlg3AAAABHNCSVQICAgIfAhkiAAAEkRJREFUeJztnX/QLXVdx1/PNTW6/Lg62JDZRI1oEnkvglQadknQUWcMCXMibM6MQwk5ypBlNNQ8aKVJ5vXmUCqDD5AJihMOCRMBMqKIAQryQ3FwfCqTQQSVIOlyk/747PE5z3HPObvf/fH5fva8XzNnzr17ds/u83nt57vfz9nd766srq4ihBBCCCGEEEIIIYQQQgghhBAAWxzW+SfA48B7HdYt6vH7wBeBh4rXZ4FXuG6RqIrcxeRM4CbM2f3A5cBhrlskqiJ3MZE3IYQQbdK0vlat3D+qm/yRA1/UH/ZHDvyRAyHEsjOzjun7BOIvAadgnUORP18H/hg4AjgSuBa4DHiu50aJSshdTHYC5wIvAH4N2AtcDTzVcZtENXYidxHZibwJIYRoh2cBJzdYXrWyD6qb/JEDX3ai/rA3O5EDb3YiB0KI5WY7cEzZBys9DmF6APB5rCj6M+AO4A19rVy0xoPYlTnv894QURu5i8e+wHeB47Er4EQc5C4m8iaEECKF/YAPAycCjyYsr1o5L1Q3+SMHfqg/7I8c+CMHQohlZDc2EspXJifOuwPxEODtwC3Y7duPFe9XA6cBP1ZzA94PXIpdTSa6o21vY54A/BZ2EL2h+WaKEuQuJl15A/sxagtWQIv2kbuYyFtcunQnmiM/+SNH/XAtNozo0TWWeRewi7STh6BaORdUN/kjB/6oP+yPHPgjB0KIZeRtwAeYOmdYdgfiCnA28BbgSVin7YvYlRc/DbwEu4X701Qvqk4BXg/8MrAHuA5dVdk2XXgD+AXsGQQ/Cvw38NvAFa1ttQC5i0pX3ia5BBsO60jg/xpur9hA7mIib3Hpw51IR37yR476YwX4NvbD4QHAwxWWOQK4gPRnJalW9kd1kz9ykA/qD/sjB/7IgRBiWXkf8CngQ+MJP1Iy0/nACLgLOAm4berzfYAzgGdWXOmzgb/Eitk9tTZ3eRgBH8TGmb0u8Tva9jbmbmAHsA34DeBCbGzwOxK3c2iMkLuojGjmritvY84BXoS1neqwbjAi35wbI3fljFDORWRE/jm37IzIO7eWnRHKoUgcgp04/BLVTh4CnIX1s1NQrbyYEc1zaBGqm+YzQg68GdG9A1B/eBYj+ok/yMEsRsiBJyP6i/+yM0Kx7osRinUZFwAXAR/BRrz5oSFMz8CC9yXsIe7TxSnA94C/wIbJAQvy41gDexTwcewW78eBn8eupDwQ6/jtLV6/Wiy/F3hy8T0nFBv1OexK2jLOLr73d6v8tUtEijdY7A6skL0HuBl7BsGtwOlT3y136Xi6k7d0uvQGNgzW7wAvxhxOI3fpeLqTt3SUc3Hp2h3ITxP68ANy1IQUR4p3OkcU77dUnP8ZwCuBj86ZZ16+HItq5a5RzeuPaldf1B/2R7WkL3X6rXLQDaod+kN1dPcMPW43YDXICeMJkycQfwIrPPcCv4kNGzGP7xXvzyveDwOuB76P3er4j8CXgcuw4Sh2TLxuBi4u/j2+0vI+4F+xnfuPStb3s8X0m4DzFmzbMpHqDRa7K2MLNqzIJHKXhrc7eUuja2+7gZOxg/5dM75T7tLwdidvaXh7A7lLpa/jnPyk0Wc/RI7SSHWkeKdzZPF+c8X5X4MNJfu1OfPMy5eLUa3cNap5/VHt6ov6w/6olvSlahskB92h2qE/VEd3zzLE7fPYM6mBzUOYno510D5IvWEixjvmr2BXS9449fl3itckj2BnvyfX8xngVcADbBRuk+zGnvlxGrbzCyPVGyx29w7gE8B/Ys8BOQkbRuQVU/PJXRre7uQtjS69nYt1WI/H2siDiukPs3kYLblLw9udvKXh7Q3kLpUu3U0iP2n05QfkKJVUR4p3OnVPIB4LfGHBPIvy5YGp/6tWbhfVvP6odvVF/WF/VEv6UqXfKgfdotqhP1RHd88yxO1W4E3YBV3fn7wD8fji/aKaXzjeMd/E4gZgEf+LXeXxnKnpr8Q6j++nejG3LKR6g8XuDgL+AXsewTXA84GXAVeWzCt39cnBnbzVp0tvp2JF8zXAvROvN5fMK3f1ycGdvNUnB28gdyl06W4a+alPn35AjlJo4kjxrs8W4HDseUe3VlzmF1l8cretellO01DN649qV1/UH/ZHtaQvVY7DctAtqh36Q3V0Pww9bncA+wOHAqysrq4C7IsNifN48e//qfhlW4GHgG9hQ+y0cVb1QuC1wE8BXwf2Ae7EGvJnAd9uYR2erDN7fNwyLsCee1JGqjeQuxTWGaa7oXuD9tzl5A2G724d5VxU1lHORWSdODn3duxZZS+ZmDZ0PxArt5bR0Tp55NAYxXszH8LuLpjFz2HPmrwTG/ZpEQcC92PPOFmdMY/6EPVYp70cAvUFUlgnbwdDjz+060A5UJ91lAPerKMc8GSd/nOgrG4AxXqarmI99DhD+7GGYcftOOAq7E7Ly8ZDmD6teH+IesXpduxKzU/Q3i2Z4/F4D8WCfybwM8Dr2Bz4M7GHOT4bO+t7YzGtzvA+pwF/iCXVndgwQddXXDZ1/buAbVPTdgC/ju2c61Ofzbv6NdUb+Ll7ERbzI7C4vxq4NGFdcteeuyg512TfactdTt6gujtoFvumyyvnNlPVWxvtpXJuOfsoqctHyrm/wu4SmiRKm7gsudXEkXf7l7p8Ljk0JkpOpC7/VeDRGuv4xoLP6w5f+pPF+0Nz5onab2+agzn0/cC3L9A0hnJQTpQcyOFYD7FzAOLXoBC3llQOzCZKOwT+/VlIr+0gTnuTuv5cYh2lXYF0T23HGuLsnynLj+ubp8PGMxAfKd73AZ5AedKWMb4t9nML5pt1JUEZk8H/KvbQyRuxZ39MshMbo/omYAV4K3B1sdyDFdbzGuA9WAA/jd2ufmWx/H9UWD51/btKpo2wHXYNuK7CusekeoNq7up4g2rutgK3FdM+VnVjp5A7oy13UXKuyb7TlrucvEF1d01jr5wz+s65pu2lcs7wyLmd+LaXqctHyrnp52tDnDZxGXILmjnybv+i59CYKDmRuvyLK3x3HcYnEG+pOP/W4v27c+aJ2m9vmoOp628zh8C3L9A0hnJQTpQcyOFYD76/2Xkfy3ey3Dng3QYpB/zboRz6s5Be20Gc9iZ1/bnEOkq70sRT27GGOPtnyvLj+mYrbJxA/CZ2pvVgrIG7Zs5Kt7BxFnu8Yy66SnPWlQRlTAb/2GIbT8OG75nkpVP/fy32x70QuLzCes7AdpAPFP9/IzbO/qnYGeNFNF1/G6R6g2ru6niDau6upPx5EnWQO6Mtd1Fyro19pyk5eYPq7prGXjln9J1zTfd55ZzhkXPe7WXT5dugS3fbsCv6dmAd8TFR2sRlyK2mjrzbv+g5NCZKTuQQb7AfDqH6HYgrxft0PCeJ2m9vmoM59P3Aty/QNIZyUE6UHMjhWA++v9l5H8uXPQe892HlgH87lEv/KrW2gzjtTZT93btG8/bUNlH2z5Tlx7XlClixOWZ8JvZc7PkP06wUX37xxLTnAXuA2xds6HewZ3hU4R6s0X419tDJvwO+UGG5/bC/p8pVHE/CCsSrpqZfBbyg4nY2WX+bpHiDau7qeIN0d3WQu/bdRc05L3LxBtXcNY29ci6fnKuDci6v41yf7WVO7rtytwN4DHtW2SRR20QvusytJo6aMiTHqY7GRMiJXOK9BTgci1eVIYtg4y7R/efMk0sfwqvv5b3+nPoC3gzFQdQc8CKn3+zqMKQaNJccWFZyyoE+98Fc+leQXttB3PbGiy7raG9y9BRh/0xd/oDi/RHYfAJxN3A+9pDH27Hxct8NvBP4MHZL4xXYjgbwZOwM6+3YzjmLbdiZ1+3z/poJ9gBfK5b7JvCnFZfbhRV7N1aY90BsKKD7pqbfBxxUcX1N1t8mdb1BNXd1vUG6uzrIXfvuouacF7l4g2rumsZeOZdPztVBOZfXca7P9jIn912524EVPdOfR20TvejKDzRz1JQhOU5xNEmEnMgl3s/Bhuh5FPhb4LyS1ztKthFmn0DMqQ/h1ffyXH9ufQFvhuIgag54kNtvdnUYSg2aUw4sI7nlQJ/7YC79qya1HcRtbzzouo72JkdPEfbP1OXH9c29sDGEKVhj+TpsLNZTgKOA44CHi5k/ixWt/1zMfxjwRBY/I2LelQSz+DLwTOAtzB4HeZJzsAdSHk294UembyldKZlWhdT1t0Fdb1DNXYo3qO8uFbmbzTLknCc5eYPq7prGXjk3mz5yLhXl3Gz6Os55tZc5uO/S3aw7hKK1iZ505QfacdSUIThOcTRNlJzwjvd4+NKtWMzL+Jep/9+LXZW7bcb8ufQhPPtenuvPqS/gzdAcRMsBL3L6zS6V6DVoLjmwrOSUA177oHf/qmltB/HaGy/6qqO9yc1TlP2z7vLjOxDvgc0nEMdcUbwWcQsbz32Yx7wrCWbxFGys1Y9WmPddwMnAMRR/VAW+hTXY02daf5wfPiPbxfqnWSteTajqDaq5S/EG9dylIHfduIuUc22xRjN3OXiDxe6axl45559zKSjn8jjOebSXbbtfI7+c2w5cNOOzSG1iW6yRV25BM0dNyc3xGv3m0DS550QuOXVh8arLTdjdi2Xk0Idoo+/VBM++Xy59AW+G6CBSDrTFGvUd5PKbXQpDqUFzyIGhsEbcHPBoh3Lpzzat7SBWe9MGa/jEOvd2pQtPazSv03LfP1OXPxS7UPIu2DyEaVcsupJgmhVsh76bjedKzGI3G43wXTXWsQdLrOOmph8H3FDje1LXH4G63qCeu1TkbjFDzrkh01XONY29cm4xXeZcKsq5xXR9nPNqL4fu/olYZ/a2ks8itYlDpqmjpsjxBhFyInq8P4k9OzGVHPvtbeG9/irkWvO2xRAdRMqBKAy5lomwD+QY/2VjiO1QlP7VvLoBYrU3ueNdozUlR08R9s/U5Q8HPgXshfI7ENtm0ZUE0xwC7Mvih06eizXCx2MPoB2fSX24eC3ib4rt+jfgM8DvAU8H/r7idjZdf+7U9QbV3O2L3do75mDsYP0g9hyXKsjdfIaac23sOznTVc5B89gr5+bTVc413eeVc/PpMue828umy+fModiDwMuK/Cht4tBzqw1H3u3fUHIoSk5EjvfFwNnY9n4jYflc++1NczBK36/LvkDTGMpBOVFyINKxfqi1zLLngPc+rBzwb4ci9K/m1Q0Qp72JsL/nUKN5e2qbKPtnyvKHYzUO0P0diIuuJChjfAXnouCfCuwHXIM9f2L8evPEPCNsPNeDS5a/BDgdOAtLnqOBlwP/XnH5KuuPSoo3qObuyOLz8TznFP9+68Q8I2bHHRa7W7S83G0mSs5V2Xei0mXOQfOcUXs5my5zrml7qZybTdc5591eVlk+KjuA/wIeKPmsrTYRlFtNaMORd/s3lByKkhOR4/0V4FrghIRlc+63N83BCH2/rvsCi2I4Yn7/Ww7KiZIDUY71Q65llj0H+tiHmy6fA0NuhyL0r+bVDdDfMXcZ6rscarSh7dNRjod147Yd2B+4dDxhZXV1dca8rbC92LADmd0YdMnZwInFdux1WD4q8hYXuYtJdG9tfUdEoruTNx9vIHepvBe7Wi7lx/o6yE86cjRMFO/ZHAO8E3h+zeW8j0XL7jR6/Nv6Dk+iO4gef5ADbxR/f+TAlyh1Q1vf4UmUWEePcyo5xe3d2N2RbxtP6PoOxEVXEnTNy4E3kB64pstHRd7iIncxie6tre+ISHR38uaH3NVjH+zKvROBK3tYn/zUR46GjeI9m08C68BRNZfzPhYtu9Po8W/rOzyJ7iB6/EEOvFH8/ZEDH6LVDW19hwfRYh01zk3JJW77AS8E/npyYtd3IPZ1dlu0i7zFRe5iIm9xkbuYyFs8zgJeD1wOvBF4zHdzRAlyJJaZpwHnA6+ieuGuY5Evir8/cuCPHPii+PsjBz6obugPxVrUYRfwMeD6yYld3YHY99lt0Q7yFhe5i4m8xUXuYiJvcflz4BnYs0RU9OSJHIll5n5s6KCTKsyrY5Evir8/cuCPHPii+PsjB76obugPxVpU5bnAHUydPITuTiD+AXAZ8E/AWkfrEO0jb3GRu5jIW1zkLibyJoQQoituBi6pMJ+ORb4o/v7IgT9y4Ivi748cCCHEZu4Gziv7oOshTIUQQgghhBBCCCGEEEIIIYQQgejqDkQhhBBCCCGEEEIIIYQQQgghREB0AlEIIYQQQgghhBBCCCGEEEII8QN0AlEIIYQQQgghhBBCCCGEEEII8QP+H4Xr7Lie1hmeAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$\\displaystyle C r_{j}^{4} {\\gamma}_{2,0,2} + C r_{j}^{3} {\\gamma}_{1,0,2} + C r_{j}^{3} {\\gamma}_{2,0,1} + C r_{j}^{2} {\\gamma}_{0,0,2} + C r_{j}^{2} {\\gamma}_{1,0,1} + C r_{j}^{2} {\\gamma}_{2,0,0} + C r_{j} {\\gamma}_{0,0,1} + C r_{j} {\\gamma}_{1,0,0} + C {\\gamma}_{0,0,0} - L \\left(r_{j}^{4} {\\gamma}_{2,1,2} + r_{j}^{3} {\\gamma}_{1,1,2} + r_{j}^{3} {\\gamma}_{2,1,1} + r_{j}^{2} {\\gamma}_{1,0,2} + r_{j}^{2} {\\gamma}_{1,1,1} + r_{j}^{2} {\\gamma}_{2,1,0} + r_{j} {\\gamma}_{1,0,1} + r_{j} {\\gamma}_{1,1,0} + {\\gamma}_{1,0,0}\\right)$"
+      ],
+      "text/plain": [
+       "     4                       3                       3                       2\n",
+       "C⋅r_j ⋅gamma[2, 0, 2] + C⋅r_j ⋅gamma[1, 0, 2] + C⋅r_j ⋅gamma[2, 0, 1] + C⋅r_j \n",
+       "\n",
+       "                       2                       2                              \n",
+       "⋅gamma[0, 0, 2] + C⋅r_j ⋅gamma[1, 0, 1] + C⋅r_j ⋅gamma[2, 0, 0] + C⋅r_j⋅gamma[\n",
+       "\n",
+       "                                                       ⎛   4                  \n",
+       "0, 0, 1] + C⋅r_j⋅gamma[1, 0, 0] + C⋅gamma[0, 0, 0] - L⋅⎝r_j ⋅gamma[2, 1, 2] + \n",
+       "\n",
+       "   3                     3                     2                     2        \n",
+       "r_j ⋅gamma[1, 1, 2] + r_j ⋅gamma[2, 1, 1] + r_j ⋅gamma[1, 0, 2] + r_j ⋅gamma[1\n",
+       "\n",
+       "             2                                                                \n",
+       ", 1, 1] + r_j ⋅gamma[2, 1, 0] + r_j⋅gamma[1, 0, 1] + r_j⋅gamma[1, 1, 0] + gamm\n",
+       "\n",
+       "          ⎞\n",
+       "a[1, 0, 0]⎠"
+      ]
+     },
+     "execution_count": 136,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Remove the (-L)**(C-1) * (r_j -L)**C part\n",
+    "simplify(expand(ftmp_en)).args[2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 137,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABsIAAAAfCAYAAABd9NiDAAAABHNCSVQICAgIfAhkiAAAFn9JREFUeJztnXuwJUV9xz8LImyWBRVUUJIsGFEexS4sggVCLvKImoo8hFAaIbfIw0BSaIyCpJbUokZUJGwIovGVFYzBwAYpDATkkaggihsxIS5SUHujxg0sYkQMbzZ//GZyz507c05Pz6O7534/VbfO7pzp0z2/7vl9+zfd071o9erVCCGEEEIIIYQQQgghhBBCCDE0tgpdgIRZDvwt8EPgcWAjcDmwT8hCDRRfW2/vkdc5wJ3AI8Bm4FpgX8e0PvdTk/yEEN2Rkj7Kj6RD3XaluhV1Scl3pcaS0AUQgGKwPlEMJsQsqeir2nY6KC4QYuGSiqakSmXcJsP7cSqwHngCOBnYMzsGcGaoQg0UX1uvBN7ikd8UcClwCPBa4GngJuAFE9LtCby1x/yEEN2yHDgidCEcmUJ+JAV8dGIK1a2oR0q+KzV2AlaFLsQCRzFYfygGE2IuqejrFGrbKaC4QIiFTSqakiqVcduiyJZGvAx4HbA78PNAZVgJfAv4XeDTJd8fAnwFeDdwUcn3LwAeLhyL4bpipAtbA+yM2fxY4KmGZdwe+ClwHDbjpoylwN8BJ2KzJbvOTwjRDxcDlwD3hi5ITeRH4qMtnVDdChdS9V0pcDYwA3whcDnaJoZYRTFYfygG88tPiBT1VW07PhQXCCEgTU1JidK4rcs3wl4OnI/NJNuMdYY3YzMWzgB+oXD+gdiMiA/SXaByC7AFOGzMOeuBLwLvp3xZhzXA7ZQHBTA/KIjlumKkbVvnfBT4c5oHYGCdlK3G5AVwIVbWpgGYa35CiH54H/BJ0nt7Wn4kPtrSCdWtcCFV35UCFwJ/DLzY8fwXA89ggW5ObP32WGIVxWD9oRjMLz8hUtRXte34UFwQHzthk0OuBu4DHsMGGb8G/A5p3fMiHVLUlJQojdu6MPYi4L3A3cB7MOd+VVaAm4D9sU7yDYV0H8DWuv1YB2XKy3UA8Czw7Qnnng/swvxlH14JvAorvysxXVeMtGlrsEB0L+C25kUDrINyF3BHxfcrsVmTN/WUnxCiPzYD9wBvDl2QmsiPxEWbOqG6FS6k6rtS4GngSqx/78KxWLx1dfb/GPvtMcUqisH6QzFYvfyEgDT1VW07LhQXxMlJ2IDEwcA3MNuuw/Zg+xTw95juC9EmKWpKSpTGbV0MhH0GOBcbRV8BHAqcjg2KvRnYDVun8b6RNHsCR2HO5bEOygT2htqOwPeARyec+02sMb4N2Hrk+Irsc71jnrFdlwvT2MzGqRZ+y4W2bJ2zCvibFsoFcAFwOCaKz4zJ77Ie81uITNNvm1yoTCM7l/FZbHLHNg1/Z5p+7Cs/Us404dp3Wzqhui1nGvmuMtrwXdPItmV8Dotpftnh3OOBH2PLzEF8/fbYYhXFYIrBQDFYDEwj/19FSvqqtl3ONIoLxFzuBd6IPa/+LeAc4DRscsgPgDcBJwQr3TCYRrpSRmrPm1JjXtzW9kDYOzHjbwBeDXyn5JzHsCUTzhg5dho2ut7levsrs0/XTv0VwC9hQVTO4uzTNdiJ8bq65gjs5rsAOAi4BntVewuwT0WaNmwNsAdwDLOzbpuU70JsQ+gjmTtoO8pumFhe2XF+J2BLjHyD6ocu52W/+ftjyrIQqdseZWs/hmy324FtCdvxbctvDbmeusZH22CyTkgjwjF0u4X2XUO27wPAndhSOePYEdvM/lpmH1LF1m+PMVZRDFYfX40aagxWxx7S1/YZut1C66vigvAoLhget2D9tWcLx/8b+Hj276mSdHre1A9DtltoTRmybaEkbmtzIGxXbIDraeA3gZ9NOH90dt5RWIDY5Su9B2af33I8P1/W4eiRY3dnn4dXpCnuexbjdXXNAdnnvsBXMSH5a+Dz2KzDMtqwNcDJwE+wzfCalO9ibE+BI4Dvjvmtk7F1gzd2nN8DwJcxYT2r5Ps9suN3Yq9ti1nqtkfZ2o+h2+1fCfu6elt+a+j11CU+2gaTdUIaEY6FYLeQvmvo9nWx7a8DzwX+YeRYbP32GGMVxWD18dWoocZgrvaQvnbDQrBbSH1VXBAexQULi3zfy6dLvtPzpn4Yut0Us3XLHPs+p8UffgewHbYkwt0Tzh1lCbYEwwa628gY6gcrd2afhxeOXQdcggUBt2GjoiuxkdFVwNezc2O9rq7JheA1wK/iFoA2tXXOa5m8Rv+k8l2KdSyOw2Zy7JIdf5T5MyOP6im/25hdWudA5nMx9qDlDObPYFno1G2PsrUfQ7fbXcDbsckjIcrflt8aej11iY+2wWSdkEaEYyHYLaTvGrp9v43FPrsBP6w453gsBvjyyLGY+u2xxiqKwerjq1FDjcFc7CF97Y6FYLeQ+qq4IDyKCxYOz8HevgP4p5Lv9bypH4ZuN8Vs3TInbmvzjbDjss/La6Z7KbYu+aYWy1JkK2B/bGbgXY5pfgo8ji0XMcoJwEewZSDvwoKFs7DGMypqsV5X1+RC8HbcOwRNbZ1zEONnD7qU73RgKXAzVnf537tKzj2YyYO+beX3BHZtexWOvxGbcfwJ4gjEY8OnPcrWfgzZbncDOwB7B8q/Tb815HrqEh9fApN1QhoRlqHbLbTvGrJ98/7mwRXfbwe8Drge6+NCfP32WGMVxWD18dWoocZgLvaQvnbL0O0WUl8VF4RHccHC4YPY217XATeUfK/nTf0xZLspZuuWOXFbcSBsBpvx5fr3uSzd9timxFuwdSXrsFP2+ZMx5/iWK2dPTDDuod7MwIeBnQvHngA+DOyHzTh8PjZD7s+YDXQh7usal3++yfGtJd+tnfB7S7IyPTjm3POBG0uON7E1wIswx/E/Dcu3qOJvdeG8nbPyjKvfNvMDq+el2Cg22Br+a4CHgD8dU46UmKG9Nulifyhvk0O39Qzt3vs5Q7Vbfp//iuP5M/Tbjuv4ERhuPeXMEIe2TdIJaUR9Zmjfdw3ZbnV81wzShTrk/c2XVXx/DBYfje6ZFFu/PeZYRTFYu/2EqvgLhheDufb/pa+zzCD/X5dQ+qq4oD4zKC6A4dUrNNfySZwJ/Almy1NKvm+iv0OvnxmkK3UI+bwpZ6i2hULcVlwa8X7md27H8aPs84XZ5yPA/9YsUL5X2HZjzvEtV47v0hWLmbuXWR1ivq6cNcDzCsdWAMcCn2X+Ou+TZjwuxwZX/5HqVyY/xOyG4aM0sTXYHnVgbbAKl/K58tKe84PZNYb3xpbhOQfYHdv0b7RDdQ42k/MVWCB7R3aszpKlZwDvxuz6H9hrpF91TNsk/zbbpKv9y9pkKrY+PEu7Mkt/EnCVQ7q27/2cVOxWN31+n7/E8bdDtOM6uNYT9GvnIr7tJBZtm6QToTTC12+MMgSNyEnFbj7p6/iu0LoAYf1N3fS5bXet+P544Ens/s6Jrd8ec6yiGGwuTfsJVfEXDC8GC9lvatq/baozsfSbclKxG6SjryHbd+h+UCztW3HBXEL5LWiu5eP4Q+AvsTdJjsQmjRRpor+pPDdJ9XlT6HYN6TxvyklFC3zSz4nbigNhR9bIeJR8JtxibCmKqo52GQ9mnzuNOce3XDl5sLK+RpqtsIa10TPPWK9rlDUlx6axm2ct8M81fy9/LXjcW4FlswWb2hps1i3YEh9VuJTvfOyGPmZCfkt6zg/mOqb7sSVK7mB25D9nCls/+k5shtB7gZuydGUCXuRkTPTPAL6GvYJ/fZb++w7pm+TfZpt0sT+Ut8lUbL0E+E5WrnUO5+e0fe/npGK3uunz+3xJyXdl9N2O6/gRcK+nvu1cZAq/dhKLtk3SiVAa4es3coaiETmp2M0nfR3fFVoXQvubNnVha+A3gFuYe//H1m+PNVZRDNZ+P6Hqba0hxmCu/f8YY7CmOuObf2j/P0VYu6WkryHbd+h+0BRxtG/FBe2mn8L//m+q5VW8A7gIG2w6ktl+RZEm+pvKc5NUnzeFbtcpPW/KSUULGmt2cSDMlwexEcdl2I1685hzi5u/bQI2YyPcXbEy+6wza+8VmKPxXfc91uvqklwIqsrzPGwkeQV24+Q0tTXY655kv+NbPhg/Y3KUPJ8tY85pMz+Y65iOwu7fM0rK8GuF/5+C3fiHAtc65PNOzHl+Mvv/mcDrMQdzjkP6pvm3hYv9q9pkKra+PvuLhVTsVjd9rlnj/EtXtO1HwL2e+rZzkVR8SZUfmaQToTSiqd8YSr3mpGI3n/QhfVdOKv6mbvpx9/fh2CDM1YXjsfXbY41VFIPVw1ejYJgxmEtedfKD/vq3TXUmVX0NbbeU9DVk+w7dD4qlfSsuaDd9LPWacza2L9hdwNHYsnBVNNHfVJ6bpPq8KXS7Tul5U04qWuCTfo7/Le4R1oR8RPJS4JUVGb8euKJwfAvwFWzNXNf1MOvgu5nxq7PPWz3zjfW6uuQAbBmYf6/4fgXwFLChcLyprWH2rcQdxpwzqXxgMzZ+FmF+APdh9X0StmHhxyjfsLrIUqy9uMwYeS4W3BfXMb4ROMSxnE3ybxMX+1e1yVRtHZoU7OaTfsfs02cfkKa07UfArZ5C2HkSsfqSKj8ySSdi0Yg6DKlec1Kwm2/6kL4rJwV/45M+v6/LbHsCFtBeM3Isxn57rLGKYrB6+GoUDDMGc8mrTn7QT/+2C0Lnn4LdUtPXmNp3HYbUf1Rc0C0h/da52CDYeuxNsHGDYNBMf1N4bhIjKbTr1J435aSgBb7p58Rtbb0RBnAxtqHuaZgjuBG4F7vxfxF4Dbbp2udL0q4D3oSNdt/XYpkA9sJef/s58FcV5zwEvKdw7BisEVwz/3RnYryurtgWGzn+N0wMyliBiUDx+zZsvSn7rOpYuJRv3IyNIg/0nB/Z72zEgvoHMaF2YQ0WqN/hcO7O2JI+DxSOP4DNCvChTv5t4WJ/qG6Tqdo6NCnYzSd9fp9vqvi+K7rwI+BWTyHsPIlYfUmVHxmnEzFpRB2GUq+jpGA33/ShfNcoKfibJrpQtt/EccDthd+Lrd+eE2OsohjMnSYaBcOLwVz7/zHGYF0QOv8U7JaSvsbWvuswlP6j4oLuCeW3fhtbdvAZbK+hM0vOmcHeRIHm+pvCc5MYSaFdp/S8aZQUtKCpZv8I2h0I24JtorYO+D3gIOxV0kexyvw6tongl0rSrsMKfirw0RbLBLNLVyzJylfGDYX/74gFsV8CftAg79iuq0v2BbZh/Fr5K5g/c7ItWz+IbYD3/Iblq5qxUWQTFgAXNyjsKr+cezDHdDbV6w2PcgG2RM9h1Fs6rfj666KSYy745t8UF/tDeZvMSc3WsZCK3eqkz2fotP0wbRJd+RFwr6c+7TyOmH1JlR8ZpxOxaIQvqddrkVTsVjd9KN9VJBV/Uyd93t8s2vZV2MS/iwrHY+u358QWqygGq0cTjRpiDFan/x9rDNYWofPPScVuKehrTO3bl9T7j4oLuiWk39o9+9wa2yOsjH9hdiCsSVvISeW5SWyk0q5TeN5UJBUtqJt+TtzW5kBYznXZXx2exDY7+wC21ESbr99dlv3V4VRgO+DChnnHdl0urGXWuddhPZPXM10OXF441patwTaQ3KfiO5fyjZuxUZXfXj3mB3YDPwtc6XDuhcBbgSNwd6gPYaK6S+H4i5g/6t5F/mWspX6bdLE/lLfJnJRs3QZr8bv3i8RuN5/0e2OBy3cdy1jGWrppxz5+BCbXUwg7V9GGL1lLv9qWU6UTMWiED7HVK7Tju2K3m2/6pr5rLf3oQmh/45M+728WN0g/Pvss7g8WW789J7ZYRTFYPZpo1BBjMNf+f4wxWJuE7DcVid1uKelrLO3bh9j6j2tRXBAbof3m6uzPlaZtAeJ/btI2a+lfV0KQ0vOmIrFrgW/6OXFbm3uENeUi4PvY66ghWYxtsLYOeyW2KbFcV2i2wW7u0de427b1zVgHwZdJMzaK3IoF133ltwgT0+8xee3Yi5kVyjrO9ElM1I8uHD8aW+bHFd/8+6SsTeakZOuYSMFuPun3x/Ybedq9mL1R14+AWz2FsHMZsfuScX4EmulElxrhyxDrNQW7+aaPwXel4G98dWED85cwOR7zBxsd8o2FWGIVxWDtU6VRisHii8HaInT+o6Rgt5T1tQr1H8Ox0OKCtoi9Xn2Y1BZSeG4SIym061SfN6WgBU00+//jti7eCPPlceAU7ObO110PwTLgE7QzUg3xXFdo9sY2thsV72W0a+srsJmfLwPu90g/acZGWX7nAS+hfI+ItvN7ObA9k2e1XooJ5XHYJpr5aPmj2d8k/iIr1zeB24C3Ydf4ccdyNs2/L8raZE4qtt6euRvBL8M6yQ9jD3/6JhW71U2/P3avx0hdPwLu9dS3nYuk4EvG+RFophNdaURTvzG0ek3Fbj7pY/BdqfibuukPwO7vIlUrBcRMLLHKMhSDtU2VRi1DMViMMVhTnUlVX0PbLVV9rUL9x3AsxLhgaH6rLSa1hVSem6T6vCl0u07xeVMqWuCTfk7cFtMbYWAjoOcRNlDZgL0SO9Pib8ZwXaFZAfwX8OORY23beiPwReAEj7STZmyUcS9wS4/55bOHJjmm04Gl2OzMTSN/7xo5ZxpbQ3VZSfovYOsir8KE+zDgDcB/OqZ3yT8GytpkTiq2PjArY17OC7J/h5r9nIrdXNLnLMc217xqwjWFwMePgHs99WHncelT8CXj/Aj460SXGuHiN6ZZOPWait3q+C2Ix3e15W+mqbaNS/pJv1HHvrti+0R9esI1pUQMsYpisPap0ijFYHHGYE11JlV9DW23VPW1DPUfw7IQ44Kh+a22mNQWUnlukurzptDtOsXnTaloQV3Nnhe3LVq9enXFuUK0yiXYKK1PwFKHvbAbY7+a6ZZjN9HOVItVGUcAH8Y2R+8jv7Y4DzgxK4fP67dN08dAX21StvYjFrtdhM1ueV+D3+iK0H4E4qmnULj4ER+dCF23C71efYnJbjH7Lh/asE1b9j0b2AObgShEzPTV1wXFYK7EpBMpEZPdYtZXte+wKC7oJn2K9Km/qh8/YrFbzJriSyy2hZK4LbY3wsTwWIyNGJ8IXN9DfhuwDfCmaqabNGOjilux2ZQH9ZRfW7wB+CP8nUrT9CHpu00uZFs3IQa7LQUOBT7S4De6JLQfgTjqKQR1/IiPToSu24Var02JxW6x+y4f2rBNG7+xDfZQY1WD3xCia/ru64JiMFdi0YnUiMVuseur2ncYFBd0mz4lQuiv6sePGOwWu6b4EoNtoSJu0xthomtWAX8AXAucCTzVQ547AJ/C1tJ90jFNkxkbLwQ+g22Q7nqj9jlDRMwlRJsUabKG9jaS7wL5kXDU9SN1dUJ1K5oQu+9KmXOxjcrXhS6IEGMI1ddVDCaGTuz6qvYdBsUFIkfPmkQdYteU1CmN2/RGmOia9wO7YWvb9iUCjwBnYUHYJNqYsbEZe3XzLT3lJ5oRok2K9NgPuJs4OyXyI+Gp60dcdUJ1K5oSs+9KnWXYw30NgonYCdXXVQwmhkzM+qr2HRbFBSJHz5qEKzFryhBYRkXcpjfCxJDZDnh8wjltztjYFniix/yEEN3hcj+HQn4kXSa1K9WtaErMvit1FgOPhS6EEAmgGEwMkZj1Ve07TRQXCLFwiVlThkBl3KaBMCGEEEIIIYQQQgghhBBCCDFItDSiEEIIIYQQQgghhBBCCCGEGCQaCBNCCCGEEEIIIYQQQgghhBCDRANhQgghhBBCCCGEEEIIIYQQYpD8H0lh4Klyxtb6AAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$\\displaystyle - \\frac{C \\left(- L\\right)^{C} \\left(- L + r_{j}\\right)^{C} \\left(r_{j}^{2} \\left(r_{j}^{2} {\\gamma}_{2,0,2} + r_{j} {\\gamma}_{2,0,1} + {\\gamma}_{2,0,0}\\right) + r_{j}^{2} {\\gamma}_{0,0,2} + r_{j} \\left(r_{j}^{2} {\\gamma}_{1,0,2} + {\\gamma}_{1,0,0}\\right) + {\\gamma}_{0,0,0}\\right)}{L} + \\left(- L\\right)^{C} \\left(- L + r_{j}\\right)^{C} \\left(r_{j}^{2} \\left(r_{j}^{2} {\\gamma}_{2,1,2} + {\\gamma}_{2,1,0}\\right) + r_{j}^{2} {\\gamma}_{1,0,2} + r_{j} \\left(r_{j}^{2} {\\gamma}_{1,1,2} - 2 r_{j} {\\gamma}_{2,0,1} + {\\gamma}_{1,1,0}\\right) + {\\gamma}_{1,0,0}\\right)$"
+      ],
+      "text/plain": [
+       "        C           C ⎛   2 ⎛   2                                             \n",
+       "  C⋅(-L) ⋅(-L + r_j) ⋅⎝r_j ⋅⎝r_j ⋅gamma[2, 0, 2] + r_j⋅gamma[2, 0, 1] + gamma[\n",
+       "- ────────────────────────────────────────────────────────────────────────────\n",
+       "                                                                              \n",
+       "\n",
+       "        ⎞      2                      ⎛   2                                ⎞  \n",
+       "2, 0, 0]⎠ + r_j ⋅gamma[0, 0, 2] + r_j⋅⎝r_j ⋅gamma[1, 0, 2] + gamma[1, 0, 0]⎠ +\n",
+       "──────────────────────────────────────────────────────────────────────────────\n",
+       "        L                                                                     \n",
+       "\n",
+       "               ⎞                                                              \n",
+       " gamma[0, 0, 0]⎠       C           C ⎛   2 ⎛   2                              \n",
+       "──────────────── + (-L) ⋅(-L + r_j) ⋅⎝r_j ⋅⎝r_j ⋅gamma[2, 1, 2] + gamma[2, 1, \n",
+       "                                                                              \n",
+       "\n",
+       "                                                                              \n",
+       "  ⎞      2                      ⎛   2                                         \n",
+       "0]⎠ + r_j ⋅gamma[1, 0, 2] + r_j⋅⎝r_j ⋅gamma[1, 1, 2] - 2⋅r_j⋅gamma[2, 0, 1] + \n",
+       "                                                                              \n",
+       "\n",
+       "                                 \n",
+       "              ⎞                 ⎞\n",
+       "gamma[1, 1, 0]⎠ + gamma[1, 0, 0]⎠\n",
+       "                                 "
+      ]
+     },
+     "execution_count": 137,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Put in constraints from e-e cusp\n",
+    "ftmp_en2 = ftmp_en.subs(ee_soln)\n",
+    "ftmp_en2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 138,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABrcAAAAfCAYAAABNlJZfAAAABHNCSVQICAgIfAhkiAAAGFFJREFUeJztnXvQXkV5wH8REdIkoIIKStuAgnIZEgiCA0LDtdZOBSKU8QL9hl4sqYPUKkgHOgGtWJGSUkTrrZ9gLRZStVgoyKUVQTTSYkuNMjD5qtY0BLFcLFdJ/3jOme/Nybns2cvZ3fM9v5lv3uS8Z8/u+zxnn8vZPbvzVq1ahaIoiqIoiqIoiqIoiqIoiqIoiqLkwPNiN0CpZQnwN8CPgCeB9cBVwL4d5RYGblfqDCW3c4G1wKPAJuA6YL8e5fv2O9f6FEUJR05+VG1JHqiPUEKTk93KkQWxG5AxtrF8H45A7OSPgc3AST3Lx8i3XOx8jP6ufknpS05+Se/vPLC5p1S3ijIecvIruWGa6wyWE6my0+M04G7gKeAUYK/iGMCZLeWWAW8N27SkGVJuy4ErgEOBo4BngZuBFxuU3Qt4+4D1KYoSliXAkbEbYchy1JakjvoIZQhysls5shNwXuxGZIhtLF8yDawyOG8B8B3gnb1bGC/fWo6dnbfxKT5YjvolpR85+aXl6P2dOra2bzmqW0UZCzn5ldwwzXUGy4nmBVqW8ErgDcDuwM9CVJApy4BvA78DfLrm+0OBrwHvBS6t+f7FwMM1x3dGZH488IyXls6Sgi5Tl9tC4BHgBGR2TxOLgL9FZog+OUB9iqIMw2XA5cB9sRvSE7UlaaE+QhmSXO1WLpwDzABfiNwOGHcsP8k0IvNVPdq1GTgZuNbg3JD5Vl9M7Lwvn+ID9UuKCbn6Jb2/08Kn7VPdKkre5OpXcsA01xkkJwrx5tZByCyJDxEugboVSUYOD3T9UNwNfAn4APVLWqwG7qQ+qYPmpO6jwJ/SnWjtCVxUtGNTcf4mZDbKSuAXKueH1qWpHmPLrYtFSF/qSrovQdrqGmSZ1qcoyjC8H/gk+b0NrbYkLdRHKEOSq93KhUuAPwReFrkdqeRloWL5IfGVN/jAxM778ik+UL+kmJCrX9L7Oy182j7VrT92Qia4fBG4H3gCGTj8OvDb5NfvlTzI1a/kgGmu0ycnehnwc2RQcpLOXCOEgj+IrFH7sQDXBpgHHAg8B/xboDpCchGwC1svr/Ea4LVI4tSHw4G9gTtazpkHXAjcC7wPcfTXIjfZzcABRb03VsqF1GVfPcaQmymrgXuAu1rOWYbMSr15oPoURRmOTcD3gLfEbkhP1Jakg/oIZWhytVu58CxwDRJLxySlvMx3LD8kPvMGH3TZeZ8+xQfqlxQTcvVLen+ng2/bp7r1x8nIIMMhwDcR2a5B9jT7FPB3SEyhKD7J1a/kgGmu0ycnOh4Zp/rixDGjXMP34NZewDGIYXrC87VL9gR2BL4PPO7helPICOByD9cy4VtI53oHsM3E8aXF5909r3ce8Ncd53wGOB+ZIbEUOAw4AxnoeguwW3Gd+yfKhNZlXz3GkJsJFyMbU5+MjDC31XflgPXNNaYYth/PZaZQWdfxWWQSwbYO15hiONmqLalnijj3t/qIsEyhdquO3OxWbnwOibN/2eEaU9jLN7W8zHcs/8dFneXf22qO+Vrlw1fe4AMTO+/Lp/hA/ZLSBx9+CYbzTXp/1zNF3vE0qG59cx/wJuTZ49uAc4HTkQkuPwTeDKyI1rpxMIXG5HVovhMO01zH9LwTgZ8gS5WXGOUavge3TkdG1UKupbis+OybAIXiSOQmvxg4GPgy8tryZmDfhjJXA7+EJJwl84vPPgN2ewDHseWoZpV3Ix1xHfA6ZAPlKk8gy2ysnDgWWpc2ehxKbqY6vQTZ6PpothwYrLIb4sivCVzfCmSplG/SbDQuKK77ey3tnYv06ccqZzvGLrc7ge2IG5T7sCVj11NIbOIBUB+ROmOWW2y7NWbZAmwE1iLL7cQgxbzMVywP8HFkYKz8+4eaY9/uec06TPItV3zmHl0+xQfql+IyZrnF9kug93cK2MTUJrZPc6V43IrsW/Zc5fj/IL4b6gcO+t4Lqh87xiy32H5lzLI1zXVMztsROAqxE5MTCoxyDd+DW8cUjQj52u5BxaePZMUHBxaf+wG3I8b6r4DPI7MT6yiXtDh24ti9xecRDWWq+2EBnAL8FNmcrY5dkUGrZ4HfBB5rOK9kclZnaF3a6HEouZno9DJkD4Mjge92tPsUZD3h9YHr2wh8FXH6Z9d8v0dxfC3y6rcyS59+rHK2Yy7I7V+J+8q7D1syF/QUCpt4ANRHpM7Y5RbTbo1dthBXvinmZb5ieZCHW/dP/D1Wc8zHG2tdeYMPfOYeXT7FB+qX4jJ2uY0hnobx6ykkNjG1ie3TXClNyr0sn635ru+9oPqxY+xy03wnHKay7Trv14EXAH9fOW6UazzfoAGmLEBmyK0j3IbFkO7g1uuBX8EsgVxbfB5ROXY9cDmSxN2BjNwuQ0ZvzwO+UbnOUbSvb38WsD2yjMa9LedVGUKXNnocSm5dOr0CCXhOQJLoXYrj5RIoVY4ZqL47mH2N8yC25jLEWKxk6xkzc50+/VjlbMdckNs9wLuQiSMxfoMPWzIX9BQKm3gA1EekztjlFtNujV22IH37LGRG+Y8GrDfVvMxXLO/CQuBVE/9fjMjqYeAHNed35Q0+8Jl7dPkUH6hfisvY5TaGeBrGr6eQ2MTUJrZPc6X0eD7ylhzAP9V83/deUP3YMXa5ab4TDtNcp+u8E5Gc5auV40a5hs83t16BrJ++weM1qzwPOACZhXhPwHr6UBrbd2H+IOsR4ElkWY5JVgAfQZYSvAdJ9s5GOkOdoz6Y9pl7JxSfVxm2qyS0Lm31OJTcunR6BrAIuAWRUfn3nobrHUL74KLP+p5CftveleNvQkbCP0E6A8Mp0bcfq5ztGLvc7gV2APaJVL8vWzJ2PYXCJh4A9RE5MGa5xbZbY5YtzMabhwxcb6p5ma9Y3oWDimuW1724+PeFDed35Q0+8Gnnu3yKD9QvxWfMcovtl/T+jo9NTG1i+zRXSo8PIW9lXQ/cWPO9zb2g+rFjzHKL7VfGLFvTXKftvO2BNwA3IHlCiXGuUR3cmkFmypn+fW6i7E7F509b6nO5PsjGyIuQ109tZiHW1V9uDnxbzXfTHddbULTpwZZzLwJuqjn+MLBz5dhTwIeB/YtrvwiZtfgnbKlggJcinfN/G+pdWLRtM7K2Zx9C69JFj6HlZqLTeQ1/q2rO3bloT5MsfdcHItdFyIg4yF4Gq4GHkI22c2eGNPrx2OUM/mUN45Zb2c9f1XqWMMPw93EfWzJmPZXM4E8HtnZEfYR/ZvBvt2C8cotpt0rGKluYjTdfaXDuDP7km3Je5hrLNzFFs92b5J+pt5lTNed25Q3gLkefdr7Lp/hos/ql/szgdo80MVa59fFLMHw8p/f3lswQPzc3sX2aK/VnhjC2q+RM4I8QWZ5a873L89ax62cGjcn7oPlOOExznbbzjkPGMKr72xrnGtVlCR/APIEA+PHEv8s1zbdvOd/l+uC+JOFq4IWVY0uB44HPsvVa6l2zEJcgA4T/SPPrg3/GlpuhlczHbR34XYvPRxu+f8nE9//X89qhdemix9ByM9FpH14xcH0wu/bwPsjrnucCuyOb95VG/VxkluyrkQcKdxXH+s70XAm8F5HrfyKvmd5uWNa2Dan0YxM5gx9Zu8j5iKLssqL8ycC1hmV9yxrykZtN+bKfv9zg2jHu4z6Y6gmGl/MkLveJTx3Y2pFUfQS42Y6SMfiIklzk1rd8TLtVkou9sSlfynfXlnNKfMo35bzMNZYfkq68Adzl6NPOd/mUEpc2x/RLrrGhq322rd/1HmkiF7lBOL8Ew8dzfcklfkgl7rKJqU1sX6xcyVWvsewWhLNdAH8A/AXyNsfRyMSXKi7PW3N55mCr39gxeez7Gsab78T2BX3Lm+Y6beedCDyN9PVJjHON6uDW0V0FWniw+Nyp5RyX68PsD7vbsvzqmmNTyE06jczk60P5imzbm1F1M/2eh3SW9T3rm2Rh8flIw/flqOZ8ZFmSOoPfRGhd2upxCLmZ6PQixNAcZ1DfgoHrgy2N5gPIsi53MTvbAGA5sqb0WmQ20oXAzUWZusCijlOQgGQl8HXkNf4bimvU7VlQxbYNqfRjEzmDu6xd5bwA+E7RrjUG50/iW9aQj9xsypf9fEHD95PEuI/72BJTPcWQ8yTLsb9PfOrA1o6k6iPKttnaDhiPjyjJRW59y8e0WyW52Juc/EKqeZmPWH5IuvIGcJejTzvf5VNKXNps0l4IE3Msxy02dLXPtvW73iNN5CK3kH4Jho/nNO7akhRycxPbFytXctVrLLsF4WzXWcClyADS0czGLFVs8yvI55mDrX5jx+Sx7+sx5zuxfUEo2Tadtw3wG8CtbG3DjXON6uCWCxuATciIdyiWFZ+prEVZGtum9rwQGYFditycJa9GDKfLvmGbi895Dd8/iIwoL0YM9i0t16puqhdal7Z6HEJuXTqF5tkhdZT1bG743nd9sKXRPAbp5ysrbfjVSplTEUNyGHCdYT3vRoz7J4v/nwn8GmL8zjUo76MNPrDtxyZyBvff6SrnG4q/VMhFbjblSzvaZF9C4tuWmOophpwnyd2OpOojwN12jEW3JbnIrW/5mHarJBd7Y1O+q4+HItW8zEcsPyRdeYMPfNr5Ie43k/ZCmJjD1S+42udc/VJsueXklzTumiWnmNrE9sXKlVz1Oja7dQ6yz9Y9wLHIkmxN2OZXkM8zh1yf1cS+r3PyKyW5+IK+5U1jz6bzjkAm41WXJIQeuUZ1zy0XNgNfQ9a7NV0fuQ82mxaH5kDk1bn/aPh+KfAMsK5y/HXF520OdZdvZu3Qck454nwF8Jqa7+chN+nVleMhdemixyHk1qVTkNkhjyVaH8D9iHxPRjYn/Bjdm3EvQnRj+tbWCxBDU13f+CbgUOOWurXBF7b92EbO0O93hpBzbHKQm235HYtPmz0hXfFtS0z0FEvObeRmR3LxEX0Zk25LcpCbTfmYdqskB3tjW77s20PLN9W8zEcsPyQm+ZYrPu18Ku0F/zFHHbH9Quz6c5Bbbn5J465ZcoqpTWxfjFwpRWLarfORga27kTe22ga2wD6/gjyeOaRIDvd1bn6lJAdfYFPeNNdpOm8FMvj45crxXrmGzze3QF6ZezMy+n2/52vvjby+9jPgLxvOeQh4n+d6m9gOGXH9d8Tg1rEUMbTV749DFFRVXh82FJ9tDvwyZGPm0xGHcBNwH+IAfhF4PbKZ3edryobSpYseQ8vNRKdts0Pq2DhwfRTXWo88zHgQCSK6WI0YjLsM69gZeX10Y+X4RmQWgg192+ADl35sI2fo9ztDyDk2OcjNtnzZzze0nBOCELbERE+x5NxGbnYkFx/Rl7HodpIc5GZTPpbdmiQHe+PqF/rsQ+GLFPMyH7H8kJjkWy74tvNtPsUHJu2FMDFHHbH9Quz6c5BbTn5J464tySmm7rJ9sXKlFIllt34LWfLv58jePWfWnDODvDECbvkV5PHMIUVyuK9z8iuT5OALXGTbles0nXcCcGdNnb1yjRCDWxuB04CPer52+TraAmTDtTpu9FxnG/sB29K+9uNSth5h3BFR3leAHzrU/yCyIduLWs7ZjMhqDfC7wMHIq7+PI536G8iGbV+pKRtKl7Z6HEJupjptmh1SxwakM1Y3JAxVX8n3EKN5Ds3rEJdcjLwKejj9lliArV8pnVdzzASXNrhg249L+sgZ7H+nLzmnQi5y61u+nBHk+yFiF6FsiamehpZzEznakRx8hAu567ZKLnLrUz6W3aqSi73pW76MN2PIN7W8zFcsPyQm+ZYLvu18m0/xgUl7IWzMURLbL8SuvyQXueXglzTumiW3mLrL9sXOlVIhpt3avfjcBtlzq45/YXZwy/U5DeTzzCE1crmvc/ArVXLxBX3Km+Y6dee9Fnnh5tKa83vlGr4Ht55GNh77IPL6mM9X7K4s/nwzzawB7cPddK/XuQS4qnLsNGB74BKLOqusBfY1OO/64q8PoXRpq8ch5Gai07bZIW317T1gfSCG4zngmo7zLgHeDhxJP0P/EOLwd6kcfylbj7h3YduGSaYZth+XmMoZ7H6nTzn7Yho7WU+Sutxsy++DJFbfNWvmVkwT7j62sSVdeool5zp82BGw04GrHUnZR9iSmm6ncbdbkL7cbMrHsltVUrc3tuXLeLNtM/Q2prGXb2p5mc9YfkhM8y0bQtj5Jp/iA5P2QpiYYxJfPt+W2PVPkrrcYvglCBfPadxlxjTD5+Ztti9WrpQSse3WquLPFNf8CtJ/5uCbafLId1wZc77jSox8xzTXqTvvxOKzbr+tXrmGzz23Si4FfoC8cjqX2RbpQJOvNM9HNmBbg7yK68otiBMORSq6TEluXbND6rgNeagwVH3zEEf/fdrXPb2MWQfe18g/jQQcx1aOH4u8UmqKSxuGoK4fl5jKGex/py85p0QOcrMtfwCyx8mzZs0clL62xERPseRcJWc7Aun6CBfGqNsc5GZTPgW7lYO9cfEL64i3DMpYY/khCZ1vddHXzrv4FF+EiDlKYvuF2PVPkoPccvVLTWjcFZe2mNrV9oW0W7FJXa82dOVXOTxzSJEc7utc/UoOvsBWtia5Tt15JyJ9eL1B21rx/eYWwJPAqYhhKNdHnIvsg2zGNukgFwOfwM+IL8DVyGzMVwIPeLrmJKnocjHpyK1rdkhTfRcAL6f/ngs29e0JLKR9hu4ViAM/AdkssxyZf7z4M+HPi7Z9C7gDeAfyGz9uWN5HG0JT149LTOQM7r/TVc4L2XIz+cVI8P4w8sBraHKRm035A5C+niJ9bYmpnmLIeZLc7Qik6SPA3XaMTbe5yK1v+RTsVi72xqb8gUgfj8VYY/khCZ1vddHXzrv4FF+Eijlc/YKrfc7VL8WWW45+qQmNu+LSFlO72r5QdstVr2OzW77oyq9yeeaQ67Oa2Pd1jn4lF1/Qt7xprlN3nreVBkK8uQUyInoBc3dgC+Tm+2/gJxPH1iGv4s54qmM98CVghafr1ZGCLlORW9fskCbuA24dsL5yxlKb0TwDWITMRt0w8feeiXOmkHVVFzdc4wvIesnnIUHF4cAbgf8yLG/ShtjU9eMSEzmDu6y75NxV/qCijWU7Ly7+HWsWdy5yMyk/yRJkk8xrW39VHGxsiamehpBzW/nc7Qik6SOg23ZM4eYjuq6Rmm59yQ3SsV2p2K1c7E1fv7Arsl78p1t/VXjGGMsPyRD5VhM2dt7Wp/giZMzhGhu62udc/VJsueXol+qIHXeBxtRtMbWL7Qtpt1z1Oja75Yuu/MqXfZwibL6T67Ma1zxxLvqVXHxBH9ma5jrBc6J5q1atCnXtuc7lyOhm6MRib+Tm2z9wPWPDRm5LkM69M81OtIkjgQ8jG+YNUZ8PLgBOKtph8/qua/kUGKofq6ztSElulyKzad7veJ0QqC2Ji4kdmYs+wtc1ciSVPpGy3bIlFdmCbBa9BzLjUcmbWPmWrZ238Sm+yN03qV9Sv9RE7Hsb0tFTLLpialvbF1u3c12vNuTynMbXNXIjJbml7FdsScVmmOY6wXOiUG9uzWXmIyOtJwE3DFDfOmRDtuUD1DUmbOTWNTukjduQ2aoHD1SfD94IvBN7Y+daPiZD9+O5LGsXUpHbIuAw4COO1wmF2pI49LEjc9FH+LpGjqTQJ1K3W7akIFuQWeArkFmPSv7Eyrds7byNT/FF7r5J/VKc8pC+X4p9b0MaeoqBaUxta/ti63au6tWG3J7T+LpGbqQit9T9ii0p2AzTXGeQnEjf3PLPecDvA9cBZwLPDFDnDsCnkLVinx6gvrHQV26us0NeAnwG2TTPxIgMNRtF2ZoY/VjJl9XAGuD22A1pQG1JHPraEfURypCkbrdy53xkU/I1sRuieCNGvuVi5/v6FF+ob1JsSd0v6b0djz4xtY3tU93mgz6nUfqQul/JGdNcZ5CcSN/c8s8HgN2QtVuHMrSPAmcjyZZijqncfM0O2YS8/vnWgepT7InRj5U82R+4lzQDJrUlcelrR9RHKEORst0aA4uRwQ8d2BoXQ+ZbPuy8qU/xhfomxYWU/ZLe2/HpE1P3sX2q2/zQ5zSKKSn7ldxZjFmuY3qeM/rm1rjYHngydiMypEtuvmeHbAc8NWB9iqKEo6s/x0RtSZ6oj1BCk7LdGgPzgSdiN0IJxhD5lk87P1R/V9+kuJCyX9J7O09M7inVraKMl5T9Su6Y5jqD5UQ6uKUoiqIoiqIoiqIoiqIoiqIoiqJkgy5LqCiKoiiKoiiKoiiKoiiKoiiKomSDDm4piqIoiqIoiqIoiqIoiqIoiqIo2aCDW4qiKIqiKIqiKIqiKIqiKIqiKEo2/D97FppnBs+xVgAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$\\displaystyle - \\frac{\\left(- L + r_{j}\\right)^{C} \\left(C \\left(- L\\right)^{C} \\left(r_{j}^{2} \\left(r_{j}^{2} {\\gamma}_{2,0,2} + r_{j} {\\gamma}_{2,0,1} + {\\gamma}_{2,0,0}\\right) + r_{j}^{2} {\\gamma}_{0,0,2} + r_{j} \\left(r_{j}^{2} {\\gamma}_{1,0,2} + {\\gamma}_{1,0,0}\\right) + {\\gamma}_{0,0,0}\\right) + \\left(- L\\right)^{C + 1} \\left(- r_{j}^{2} \\left(- r_{j}^{2} {\\gamma}_{2,1,2} - {\\gamma}_{2,1,0}\\right) + r_{j}^{2} {\\gamma}_{1,0,2} + r_{j} \\left(r_{j}^{2} {\\gamma}_{1,1,2} - 2 r_{j} {\\gamma}_{2,0,1} + {\\gamma}_{1,1,0}\\right) + {\\gamma}_{1,0,0}\\right)\\right)}{L}$"
+      ],
+      "text/plain": [
+       "           C ⎛      C ⎛   2 ⎛   2                                             \n",
+       "-(-L + r_j) ⋅⎝C⋅(-L) ⋅⎝r_j ⋅⎝r_j ⋅gamma[2, 0, 2] + r_j⋅gamma[2, 0, 1] + gamma[\n",
+       "──────────────────────────────────────────────────────────────────────────────\n",
+       "                                                                              \n",
+       "\n",
+       "        ⎞      2                      ⎛   2                                ⎞  \n",
+       "2, 0, 0]⎠ + r_j ⋅gamma[0, 0, 2] + r_j⋅⎝r_j ⋅gamma[1, 0, 2] + gamma[1, 0, 0]⎠ +\n",
+       "──────────────────────────────────────────────────────────────────────────────\n",
+       "                                                                              \n",
+       "\n",
+       "               ⎞       C + 1 ⎛     2 ⎛     2                                ⎞ \n",
+       " gamma[0, 0, 0]⎠ + (-L)     ⋅⎝- r_j ⋅⎝- r_j ⋅gamma[2, 1, 2] - gamma[2, 1, 0]⎠ \n",
+       "──────────────────────────────────────────────────────────────────────────────\n",
+       "               L                                                              \n",
+       "\n",
+       "     2                      ⎛   2                                             \n",
+       "+ r_j ⋅gamma[1, 0, 2] + r_j⋅⎝r_j ⋅gamma[1, 1, 2] - 2⋅r_j⋅gamma[2, 0, 1] + gamm\n",
+       "──────────────────────────────────────────────────────────────────────────────\n",
+       "                                                                              \n",
+       "\n",
+       "          ⎞                 ⎞⎞ \n",
+       "a[1, 1, 0]⎠ + gamma[1, 0, 0]⎠⎠ \n",
+       "───────────────────────────────\n",
+       "                               "
+      ]
+     },
+     "execution_count": 138,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "simplify(ftmp_en2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 143,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABkkAAAAfCAYAAABDESp1AAAABHNCSVQICAgIfAhkiAAAFapJREFUeJztnX20HkV9xz83iBoT3gQVFNtAEeSlJJCICoI3EtDqOYq8lJYKvccWBfQgRQWxob0gKhgplCIKvgUoFJQc8KBQqYCVd0IUKBKhcLgqkgaQFoQWQzT947dLnmx299mX2Wdmnuf7OeeeJ9md3Z39ffc385udnZmxyclJhBBCCCGEEEIIIYQQQgghRo1pvjPQktnAJcCjwPPAI8DFwM4Or7EPcDXwGLAGONjhuUU+TXWd2XG+8vg09lyc6+Haoj4fAe4Fnkn+bgPe4zVHogrSLV5OApZiuj2B1ae7eM2RqIq0E0LERJt2reJ5Pyi+84vq+TiRbn6R/YUIlyqx4Iy2JwiVI4BlwG+BQ4Htk20Axzq8zgzgHuCjDs8pimmq61zgsG6zth5vAY7EgnsRB48Cn8Kel3nADcBVwK4+MyX6It3iZRw4D9gTeAewGvgB8EqPeRLVGEfaCSHiYHvgAw2PVTzvD8V3fhlH9XyMjCPdfDKO7C9EqMwG5vdJszmwsGjnWMF0WxcB7wK2AZ5rmLk2zAXuAv4a+HrO/j2BHwGfBM7K2f9K4KkO8rUGOAS4ok863/YLla503QKz+fuAF5zktD+bAD/GGlV/B9yHOtJi5Snsi5DzfWdE1EK6xclM4GngAOzLKxEP0k4IESIbAf+CjfZ/vuaxiufDQ/GdP1TPx4l084vsL0RYnIONDH6wJM2JwBRweXZH3kiSediXOKfTzQv+G7DOhr1L0izDviI5jfwplM4GbiX/RTp000FSlRDsFypd6fol4LOUd5C8Afh8kocnkrRPYL3+xwCv6JP3LBdgnWU31DxO1Me1dikbAH+OPYu3ts+myCDd4qUr7cBeZk3Dbz09rHSpG0i7LulaO9EeaTQYmrRzzsTaEHU7SEDxfEgovvOP6nm3bI59HHol8BDwf9jL9JuBv8LdrC7SzS+yvxBh8Rngq5SXsWcCfwO8JrsjbyTJdcAewFZYQe6SMeC/sYJkE+DZkrR7AHcAfwt8rmf7G4HlwJ+R0+vTMVVGkoRiv1BxreveWCdJ0bDsMeAUrKfwpVjQfS8WoPwhsD82QuVmqjfIjgSOAt4KrAJ+iL4864IutAP4Y2zO45cDvwH+ArjGWa6FdIuXrrTr5XJsWpR5wO9a5lcYg9ANpF0XDEo70RxpNDiatHPmAhfSbD54xfNhoPguHFTPu+Uo4MvACuBG4BfYC7kDsTJuCfZuaU3L60g3v8j+QoTH+dgsRZeUpPk4sBPWaf0iL8kk2h5YAHwN9y/4wb7C2gR7Gd4v8L0T+BnwYeAM1hY4c5LfZTWvPQn8fZ8087EAuSkh2a8KE8A3aX/fdXCt60LsHor4Bnaf92NrltyT2T8dOB7YruL1dsA6d/bGGlQinwnaP1uutUt5AHveNgUOwqZqG8caxqK9dtLNDxOE63Mpi4B9sPJTjYi1TBCmz/Ui7dZngvB9btSZQBrFRJN2zkIsHqiL4vlqTNB9W1HxXTkTDKa9rnrePQ8C7wW+B/y+Z/unsXciB2EdJktaXEO6rc8Eg3vHJfvnM8Hg3zOOKhPI1nlcCFwMfIviGYf+GXgEOBX4eboxO/zkg9hXPF2N0Jib/FZ9EX4Z8AdYx0PK9OS3bifBucCOff7urHnOLKHZr2vmY18+LMJGiHwHG2a4Bti55DhXum6LfcF3ZcH+47FCYzm2KGO2YQvWmfVZbKqElLL7WoCtgXIftkjXauDtyfGrgZf1nOdAzCHvwL42zOOU5LwfKrrJEaUL7dJnchU25PkubM7ju4Hjes4h3ZrjUzeQdm3oUjuwIa1HAPtiOvYi3ZrTtW4g7bpiENqBNGpDE41k7+bUbedsjb2A/HbBfsXz/lFc7hcXMRpIg6bcgK1R8fvM9v8CvpL8ezznOMXWfpHf+KdOrCs7N2PY7XYrFssdWJJmJbCUzEiSbCfJAqwH9HaXuethXvJ7V8X0tyS/+/VsS78q2afgmKI5gZ/ERjCU/f1vxXwVEZr9umb35HcX4CYsADgfuBSzZxGudD0UG5Y/lbNvK6zRuhr4U2z4dhm9I3/K7usybFj4nJ6/u5Ltc1j3a7SVwL9hBfsJOdfcNtm+FBt9JIyutCt6JqdhQ/xTpFszfOsG0q4pXWt3DrZW13zsa+ws0q0Zg/A5adcNgywvpVEzmmokezenbjvnUGzas0cK9iue94/icr+4iNFAGnRB+mXz6px9iq39Ir/xT526Q3ZuxijY7cfYWme10vROtzUDCwqX082C41A/+F2a/O6T2XYNNjLkFdgL9zXY10cfwoZd39Y6p2uZybpD6GdhdnoKm1cyJUT7dU1aeL0N+/qqaueQK13fAfyk4BrHYQH2N6k/XLvfff068//nsOche51bgPcn6eexPudg81sfw/pfmIwyXWp3Ojbk+ZfYnNeHYV/wvKcnjXRrhm/dQNo1pUvtzsMaEQdg5eSWyfZnWTtyULo1o0vdQNp1Sdfa9SKNmtFUI9m7OXXbOQsobgeA4vkQUFzuFxcxGkgD17wEG4EA8K85+xVb+0V+4586sa7s3IxRsNvdwMewjy+K7uEnWMy/NfAorDuS5HXABtjCUl0wDdgNG2lxd8Vjngaex6Zm6uVA4IvYMPi7sRfsJ2BClwXLTZiXnDM976Lk36dm0oVov65JC6+PUW/0jCtd96C45/6A5PfiGvlKaXpfefwWy+OOme3vxRoAFxBOp1codKndltjcgw8A1wNvAv4EuDaTTrrVJwTdQNo1oUvtjsZefFyP1Y/p3ycy6aRbfbqu56Rddww6RpFG9WmjkexdnybtnDdT3oGleN4/isv94ipGA2ngktOxL+SvAb6fs1+xtV/kN/6pW3/Lzs0YdrvdB2yMLc5eRPo++c3phrHJycn032/F5u36FjZ8OcsUxXOV5XEJ1sOa8kZslMVPsUqhKr8CXsP6i8yHRqj2a3r9C7F5mIuYATyDTWO2Ffk9c5/HRoLsn7Ovra6vxoaInQacnNk3E5sWYU3y7zrTqFW5r7pcBBwOvB7rnZyO6bgRsD02ZVjMTOHu2QpJu2HXDdxpF5JuMPzaTSGfi5Up5HMxMkU8PlcUe0mjdelKoxTZe12y7Zosdds5WwBPYPNlT+bsVzlXnykG31asw7DbH9xqIB+ozxRuy7U8jgX+EZsyaC9sJEIv8pt6TBF2uQXSIEtX7xmH3c7g3tYw3HbbD7gOGzFzVUGa7YD/BE4EvgDrvqBO59LNzvGe8jD29X9VHsv8v+lUUdNZdy7mUAnVfilnA5tmts0B3oc5z1RmX7+vuGZjX319j+LK4wzsi7A82uq6VfL7TM6+V/Xsq9uwrXJfdUnnTdwJK3hOArbBFgjqLXROwkbT7ID16t6ebKszzcMxwCcx+/wUGzp2U8Vjm17f5bMVknZVddsHs/lczO6HAFfUvJYP3cCddiHpBvH4XNNnZ9R9DtrZve3x8rn1icXnmh4fk88VxV5VNHJRn8Foa5RS1Sfa2srFOZoc37Zdk6VuO+d1yW9eOwD8lXMuyri2fhhCPA/xxuW+7A9uNfBZ18faNnJdrmX5CNZBcj+22He2gwT8+Y3v+CyENhHEHSP78rtQ3jPGUkdAc19xbWuIp1xvcnwaI762Qpr0/fI6nSSPJ7+bFxy8b8mJq5AGv8tqHDMNewiKFuQLiRDt18vZOdsmMIdaDPyw5vnSIXB3lKT5n4LtLnSdmfw+nbMvXRNmOjYFWlFHTR5V7qtshEwevQXPw9gUYrdj81z3Mo7NcbkUGMOmdPtBclxeEJXlUCzwOga4GRsKem1y/C9Kjmt7fZfPVkjaVdVtBnBPsn1J1cz24Es3cKdd17pBN9qN49fnmj47o+5zbe0unzNG0eeaHh+TzxXFXlU0alufgTRKqWLvtrZycY6mx7dt12Sp286ZkfzmtQPAXzw/TrsyDtr7YdM8+GgrhhiX+7I/uNXAZ5s21raR63Ktl+OAs7AX3vuy9t1RFl9+M47aRBD3uyBffhfKe8ZY6og2vuLa1hBPud7k+DRGnFGwPzdNbyfJCmzY8g4VMtiEuclvnZEQO2AFRChrcJQRov26JC28ivKzKdbzOAdzpl5c6Lom+R3L2fc41os6C6tsri85T3YRn373BeUjZPLoLXgWYH53DGvvIeWdmf8fjjntXsDVFa5zPFY4fjX5/7HYvL5HYz3C/Wh7fReEpF1V3a4lf22Mqkg3o1/Z1oV2vn2u7bPjghh9rq3d5XPGKPpc2+Nd0KV2ZbFXFY1clEmjrlFKFXu7uNdhsDfUb+ek8X+2jEnxFc+7qB/a+mEIdRTEG5fL/sWobdSME7F1SO7Gpn95siStL7/xHZ+F0CaCuN8F+fY7VzSNdWOpI0Kxc0os5XqT49P4PO+dMZl9L95v78Lta4AfYXO8blchk3Vouuj4W5LfGx3npwtCtF+X7A6sAv6jYP8c4AVsfuEsLnRNv/LbuGB/2st6HjbPcZYxzKkuy2zvd19gPde/qZZNAB7CtDsEWwDpy+QvRJ9lI0z7Kl8OvBRrYF6X2X4dsGflnDa/vktC0a6pbnWQbtV0g8Fo59vnfBGTz7W1u3xudH0uJJ/tSruy2CuGOm0YNErpZ28X9zos9m7SzunXDgglnvdVP4SQhxjj8i4YFvtDHPVIHj798GSsg2QZNoKkrIMEwvGbUW0TheQ3g3xuQ9KwaawbQx0Rkp1TYijXmx6/SfL7XEmajbNpsotmLwEOwnoxH+qX0xrsiA1feQ74p4I0TwKfymzbHxPsOw7z0iWh2a8rXob1NN6LFWB5zMEKrrz9LnRdkfwWNY7OAXYFPogVsNcBD2IF6uuBtwFbA5f2HFPlvsq+0ixiFTa12HbY14nZheaLOBtrLN5eIe0W2JQQKzPbV2I9wk2oc32XhKJdU93qIN366waD0863z/kiJp9ra3f53Oj6XEg+25V2ZbFXDHVa7Br10s/eLu51WOzdpJ2T5jmvHRBSPO+rfvCdh1jj8i4YFvtDHPVIHr788C+xKZN+h82bf2xOmins62gIy29GsU0Umt8M8rkNRcM2sW4MdUQodu4lhnK96fFpjLiiQpoX15jK6yRZCRwBfKlfTmuQDqGegS0Ak8f3M//fBDgA+C7wS4d56ZKQ7NcluwAbUj5v8BzyvwZzpevj2CI7mxXsX4PZaglwJLAHNrz1WcxJbsMWg/puzzFV76voK80yfoYVPCdSPF94L4uwxZH2pt5wzuywuLGcbVVoen0XhKRdXd2aIt3KGYR2vn3OJzH6XFu7y+fKGWafC8Fnu/S5si/xY6nTYtUoSxV7u7jX2O3dpJ2zAutUyS5gCuHE8z7rB9958B0jhMKw2R/iqUdSfPrhNsnvBtiaJHn8O2s7SULxm1FtE4XkN76eW98ato11Y6kjfNs5Syzlet3j05EkZQMYNsumyXaSrMIWQ/kcNuzZ1TCbi5K/OhwBvBw401EeBkFI9qvCYtZWynVYRvm8bgCzgYtztrvUdSmwc5801yR/VahyX2VfaZaxGTYn3rcrpD0T+AAwn+ojkp7EKtAtM9tfzfo9rl1cP8timj1bvYSgXR3dmhCabtBeO9e6Qffa+fY5FyxmNHyurd3lc6Prc659djHh+VxR7JUSep0Wu0ZZyuzt4l5Ds3dTmrZzlmKjULKEEM+7qh/a4DOejzUud4nPGCEEH2hKiHFaUyaTv6qE4Dej3CYKxW98PLehxF9tY93Q64gufGUx7WPd0Mv1psfvhH1Qc39JmvR98h3phmk5ic7CVoc/tV9OO2Q6tvjKEmxoYkyEYD/fbIg9kNkhiK51vR6rqAZJv6808xjDCvMHKJ8PD2x6h7RSLHPmLKuwSmW/zPb9gFtrnKfp9WOgrnZ1dGuKdKtGl9r59rlhpgvd2tpdPleNYfS5YffZotgrJYY6bZg06mdvF/c66va+EfsorQldxvMh1A8h5KEfIcblrhhG+0Mc9UhKDBo0YRjjs5gI9V1QW2LRsCzWjaGOCNHOMZTrTY/fDVs3fHWfNMvpmZIrO5IE4HngcMwx0/lhB80s4ALa94j5IAT7+WYnbHGdbAUyC7e6XoaN2vkj4GFH5+xHv68083gDMJP+I4vOwyrFA7AFutKe0meTv378Q5K3O4FbgA8DrwW+UjGfba8fOnW1q6rbTGx4YsosLIB6Cusw7Yd0609X2vn2ubbPTuh0pVtbu8vn+jOsPtf2+JApir1SqmjkokySRkYVe7u411G292XAKVh+H+uTNktX8byL+qGtH8ZSR4Ual8v+xaht5J9hjc9iaROF/C7It98NgrJYN5Y6IjQ7x1KuNzl+NyxOLGN3LJ58kbyRJGC9Lafg7wX/cmxo4pSn67fFt/18Mwf4FfDrzHbXuj4CXAUc6Oh8/ej3lWYR6Vdu/Qqeo4GNsBEyK3r+PpHsn8Dm3JtVcPzl2HynC7GKY2/g3cDPe9KUnaPf9WOmiXZVdZuXpEnTLUr+3TuabIJiu0u3crrUrortJuhOuyrPTqx0qVtbu8vnyhlmn6tyfKwUxV4pVTRqW59Bfxu3PT4Wqti77fNc5Rxtjw+ZB4EbqN8O6DKeb1vGQX8/7Hd8DHVUyHF52+OH1f6gtpFvhjk+i6FNFPq7oEH4nW/KYt1Y6ojQ7BxLuV7XbrOxRdmvKL4ltsLWxft678axycnJkmOEaMS5WK/eIDovdsQcZtcBXGs25pBbUPwSoktOAQ5O8lE2ZKzrc8RI7NqNqm4g7WJFusWLtIuTQcVe0mewyN7lzAe+ALypxjEq4/wjDfzi2/4gDZrgW7dR1yx2+7s6h08U64ZNSHY7Cxvl8pmSNCcC22KjUl6kaCSJEE2YjvUwHgxcO6BrLscW2RkfwLX6faXZNe8GPkq7AsPFOWIkdu1GVTeQdrEi3eJF2sXFoGMv6TNYZO9ybsRGqO9R4xiVcf6RBn7xbX+QBk3wrduoaxa7/V2dwweKdeMgFLttBOwFfLEkzYZYZ9vC7A6NJBEuWQgcBVwNHAu8MKDrbgx8DZvDcVWH1xnkCBnhFmkXL9IuTqRbvEi7uPAVewkRCq8CvgG8n2oNa5Vx/pEGfpH940S6+UX294diXVGHs4ElwE0laU4G7k/SrYNGkgiXnAZsjc2nOMiC6xngBKyTpAt8jJARbpB28SLt4kS6xYu0ixNfsZcQofAENkXDYX3SqYzzjzTwi+wfJ9LNL7K/fxTriqrsCtxHeQfJLOzj+vU6SECdJGJ4mAIu7ejcH8cWiL8SWNzRNUQ3SLt4kXZxIt3iRdoJIWLlLmyNwjJUxvlHGvhF9o8T6eYX2V+IeHgAm2WojJXAGUU7Nd2WEEIIIYQQQgghhBBCCCFGEo0kEUIIIYQQQgghhBBCCCHESKJOEiGEEEIIIYQQQgghhBBCjCTqJBFCCCGEEEIIIYQQQgghxEjy/1RkeTvFXFloAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$\\displaystyle \\left(- L\\right)^{C - 1} \\left(- L + r_{j}\\right)^{C} \\left(C r_{j}^{4} {\\gamma}_{2,0,2} + C r_{j}^{3} {\\gamma}_{1,0,2} + C r_{j}^{3} {\\gamma}_{2,0,1} + C r_{j}^{2} {\\gamma}_{0,0,2} + C r_{j}^{2} {\\gamma}_{2,0,0} + C r_{j} {\\gamma}_{1,0,0} + C {\\gamma}_{0,0,0} - L \\left(r_{j}^{4} {\\gamma}_{2,1,2} + r_{j}^{3} {\\gamma}_{1,1,2} + r_{j}^{2} {\\gamma}_{1,0,2} - 2 r_{j}^{2} {\\gamma}_{2,0,1} + r_{j}^{2} {\\gamma}_{2,1,0} + r_{j} {\\gamma}_{1,1,0} + {\\gamma}_{1,0,0}\\right)\\right)$"
+      ],
+      "text/plain": [
+       "    C - 1           C ⎛     4                       3                       3 \n",
+       "(-L)     ⋅(-L + r_j) ⋅⎝C⋅r_j ⋅gamma[2, 0, 2] + C⋅r_j ⋅gamma[1, 0, 2] + C⋅r_j ⋅\n",
+       "\n",
+       "                      2                       2                               \n",
+       "gamma[2, 0, 1] + C⋅r_j ⋅gamma[0, 0, 2] + C⋅r_j ⋅gamma[2, 0, 0] + C⋅r_j⋅gamma[1\n",
+       "\n",
+       "                               ⎛   4                     3                    \n",
+       ", 0, 0] + C⋅gamma[0, 0, 0] - L⋅⎝r_j ⋅gamma[2, 1, 2] + r_j ⋅gamma[1, 1, 2] + r_\n",
+       "\n",
+       " 2                       2                     2                              \n",
+       "j ⋅gamma[1, 0, 2] - 2⋅r_j ⋅gamma[2, 0, 1] + r_j ⋅gamma[2, 1, 0] + r_j⋅gamma[1,\n",
+       "\n",
+       "                       ⎞⎞\n",
+       " 1, 0] + gamma[1, 0, 0]⎠⎠"
+      ]
+     },
+     "execution_count": 143,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ftmp_en3 = simplify(expand(ftmp_en2))\n",
+    "ftmp_en3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 144,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABYsAAAAfCAYAAACmuZLoAAAABHNCSVQICAgIfAhkiAAAEM1JREFUeJztnXuwJUV9xz93wQcC4gOVKFbQEh8E2UUQExFzEdBSqxQ3EEt83VIxsFpIoQaxMHXxEY1oJKuFopYs4AMjlFhEUMJLQURhdYOAQmF5xQdBwCiBqMvK5o/fzN7ZYc6Znp6Z090z30/VqbN3Zvr07O87v+7f9HT/Zm5xcREhhBBCCCGEEEIIIYQQ42ZFgDrfDWwGPhGgbtGMtwDXAXdnn+8CLw16RsIVaZcmJwDXYJrdAZwP7Bn0jIQr0k4IkRJt7gEUy4dBsV141NenhzQLjzQQIk6mxoKzHiz+a+BILNAR8fNL4F3APsC+wKXAecBeIU9KOCHt0mQeOBV4LvACYBNwMfCogOck3JhH2gkh0uCpwGs8yyqWD4diu/DMo74+NeaRZqGZRxoIESMrgQMn7ZybYRqKnYAfYAHmPwHXA2+dVeWiM36LPR08LfSJiMZIu/TYAfg9cCj2FF6kg7QTQsTIjsCXgMOAPzYsq1g+PhTbhUV9fXpIs/BIAyHiYS22Uuzm8o5pM4t3Bz4IrMeWC9yXfV8MrAEe1vAkPg2cgz0FF/3RtW452wCvwhr3q9qfpqhA2qVJX7qB3dSvwG4GRfdIuzTpUzfRDdJoNlyKpYM4oEGZjwKn0HygGBTLx4RiuzhQX98djwbeBHwVuAX4AzageCXwRrpbES3NwiMNhIiH9wGfoaKNrZpZPAecBBwPPBgLQK7DGuu/BF6ILRm4Evfg9EjgKOBvgI3A5Wg2Qtf0oRvAM7GcaA8F/hd4NXBBZ2ctQNqlSl+6Ffkytlx4X+DPLc9XLCPt0mQWuol2SKPZMQf8D3bTvRNwj0OZfYAz8MsVqVg+DhTbxYX6+u44CvgkcBtwGXAr8DhgNdbGnQscjj0ga4M0C480ECIuTgO+DXyhuHHbigM/BywANwJHAP9V2r8dcBzwFMeKnwb8M3ZTsNH5dMfFAnA6li/kcs/f6Fq3nJuAVcAjgL8DzsTyDl3veZ5DYwFplyoLtNOuL91yTgaej7WdCqSWWSBen8uRdtUsELfPjZ0F4vctsczu2ADKj3EbKAY4EYsFmqJY3o0F2vtQHYrtprNA/xrkqK/vlpuBlwFfB+4vbH838H3sel+NDRr7Is2qWUB+E5IFZmf/sbOAbF3FGcBZwL9jqwGBB041Pg4z4I+xF1iUg3ywJSEfwJYRghl6M+b4+wFfw5YUbAb+CpuBsDMWxGzKPn+bld8EPCT7ndXZiX0Pm31SxUnZ77657n87Mnx0g3rtwG4KbgGuxXKibQCOLf22tPMnpHbSzZ8+dQNbJvw64CBMwzLSzp+Q2kk3f/rWLUca+eOjkeztzz7Z93rH43fFBmK+MmH/NF85GLdYHqRpGxSXh0d9fTguxfLX3l/a/t/Ap7J/z1eUk2ZhaRJnSYN+UKw7G4Zst6uwWG51cWNxsPgvsAB+E/D32NKmafwh+35W9r0ncAXWwJ8GfBH4CfaW3mdiT8Hzz7XA2dm/8xkKtwP/iV3g/1hR35Oz7dcAn605tzHhqxvUa1fFCmzpWxFp50do7aSbH33rthZ7S/2B2Oy8KqSdH6G1k25+zLKtlEZ++Goke/uzb/Z9rePxr8TSgfxswv5pvnI2brE8SNM2KC4Pj/r6OMlnum2q2CfNwuLabkmD/lCsOxuGbrcfYO9C2EIxDcWxWLBxOs2WMuUX5/OwWQZXl/b/LvsUuRd72lGs5zvAK4C7WA6Ai6zF8t+t4YFPHMeMr25Qr92HsKVAv8By4h2BPdF9aek4aedHaO2kmx996nYqFkgdirWRu2Tb72HrZcbSzo/Q2kk3P/rUrYw08sNXI9nbn6aDxQcDP5yyv85X7ir9XRXLgzRtg+Ly8Kivj49tsdmoAN+o2C/NwuISZ0mDflGsOxuGbrcNwNuwh9D3w9Yziw/Nvs9q+KP5xfk26i/MOv6EPWl6Rmn7y7BA6NO4B8VjwVc3qNduF+DzWH60S4BnAy8GLqw4Vto1JwbtpFtz+tTtaOwG8BLsBR/55x0Vx0q75sSgnXRrTp+6VSGNmtNGI9m7OSuAvbF8jxscyzyH6QP5iufDo7g8POrr4+ND2IzJC4BvVuyXZmFx6TukQb8o1p0dQ7bb9cDDgT3yDXOLi4sAO2BLBjdn//4/xx/cHrgbuBNbgtjFCPqZwGuBJwK/xF6GcgPWwDwVe/NzyiwxOcdJFWdgOQCr8NUNpJ0PSwxTu6HrBt1pF5NuMHztlpDPpcoSafjcB7Hcry8sbR+6RkvE4Vs5svfWfAGbhTWJp2O5oW/ABlHq2Bm4A8ult1ixX/1Tc5bozodAGviwRNwayP5bU9euVXEM8G/YUvr9sVmpRaRZc5bozm/UbjVnidm3W4p13aizdc5Q7XYIcBE2e/o8WE5D8Zjs+26aBfkrsdkN5beWtiHPq7IHZvwTgCcBb2Rrw5+AJWB+GjbCf3W2rcnyxzXAOzHHugFbRnmFY1nf+k/B3mBcZBXwcuwCXSrtmzZjxFc3CKfd8zGb74PZ/XDgHI+6pF132qXic22una60i0k3cNcO2tm+bXn53Nak4nNtyqfic/9C9du4XTXqok8LoVEsvpWTSlvmW/6nwB8b1PHrmv1NU1A8Ifu+e8L+lOP5tj4YQ/8E6cblXbSBQ9UglX7E1/5dt2tl3oINFN+IvRCtPFAM443PYrgngnH3HRA+/oI0Yt2h2Donlba9afk8Rnx8viEfLL43+94O2Ibqi6mKfMr792qOm/Q0o4qi8X+KJYm+GsuDV2Qey39zDTAHvBe4OCtX1ZmUeSXWAa0BrsSWR1yYlb/Vobxv/adUbFvALtp1wOUOdef46gZu2jXRDdy02x57Q/rpwLmuJ1tC2hldaZeKz7W5drrSLibdwF27traXzxlj87k25VPxufI7FXJcNWrbp4XSKBbfykmlLfMtf5DDbzchHyxe73j89tn37yfsTzmeb+uDvvV36UOQblzeRVw/zzA1SKUfmcfP/l23a0WOBT6GDfwdBPxmwnFjjc9iuCeCcfcdMcRfkEasOxRb56TStjctn8eIecy4ZbD4N9jI+m6Y410ypdItCY9ZvjjrZjZMeppRRdH4B2fnuAZb3ljkRaW/X4v9B/cHzneo5zjsIvlM9vcxWN6vo7GnA3W0rb8LfHUDN+2a6AZu2l1IdW61Jkg7oyvtUvG5Lq6dtsSkG7hr19b28jljbD7XtnwX9KnbI7AZAKuwYK6Iq0Zt26Wxa5STSlsWg73BbrrBfWbxXPZdtmdOyvF8Wx+MoX+CdOPyLmKzoWqQSj8Si/1zjsfyFG/AlkXfOeXYscZnMdwTwbj7jljigRRi3aHYOieVtr1p+Tw+z2PGrV5wl4+8n4rlQiszl/342YVtzwI2Aj+qOdHfYfnsXLgFa0wOx5JEf5Lpb2/O2RH7/7g8SXowFmhfVNp+EfBcx/NsU3+X+OgGbto10Q38tWuCtOteu1R9LhSx6AZu2rW1vXxunD4Xk8/2pdsq4D4s92uZFPqzIWiUk0JbFou9fV5ul8/+fviE/anG830Qqv5U4/I+GIoGKfQjVYT0wfdgA8XrsRnF0waKIR7NxnpPNNa+IyYNY4912xKTrXNSaNt9yu+Ufecx45aZxQBrgb2AN2AX20XAzdjF9UTgecCuwBez4x+CjaZfh12gk5j2NKOKjcDPgKdgs1Xe41AG7EZlA25vgNwZWyp5e2n77djTAR+a1N8lTXUDN+2a6gb+2jVB2nWvXao+F4pYdAM37draXj43Tp+LyWf70m0VFjxX7U+hP0tdoyIptGWx2PsZ2BLBe4GPTzjmTuBdhb/zc64aLE45nu+DEPWnHJf3wVA0SKEfqSKUD74eSyXwZyyn5jEVxyxhM+UgLs3GeE805r4jFg1TiHXbEouti6TQtvuUz2PE2/INxcHizVhS5nOBI4H9sKUf92QFvoslzv6P7Pg9gQdRny9t2tOMSfwEM/7xTM6xUuRkLIH0ATRbnlWeKj5Xsc0F3/q7oKlu4Kadj27QXDtfpN1kxuBzIYlJN3DXrq3t5XOTGbLPxeCzfeo2bWZmKv1ZqhqVSaUtC23vPAXF9pjNq/hm6e/bsMHl8oteYBjxfFeEqj+GGCEWhqZBKv1ITkgffFL2vQ2Ws7iKb7E8WByLZmO9J1LfEV7DlGLdtoS2dZlU2vYm5fOZxbfkG7atOOiC7FPHegr5LKYw7WnGJB6J5cz4isOxHwVeAxxI4T9Ww51YQ7JLaftjeeDoex/1l1nHcsfni6tu4Kadj27QTDsfpF0/2qXkc12xjnbaxaAb1GvX1vbyuXH6XB8+u464fG4lcNaU/bH3Z11rtI7Z+laZ2NuyWPqxM7NPU67BZiWXSTme75KQ/VPKcXmXDFGD2PuRIqF9cDH7uBKDZmO+Jxpz3xFL/JVCrNuWWGxdJva23af8HtjEghvzDSsmHNgldU8zysxhF/VNFPJlTGAty43DjTXHFtmIOdchpe2HAFc1+B3f+lOgqW7QTDtfpF09Q/a5IdOXz7W1vXyuniH63NB99kFYUDRpSWQK/dmQNEqhLUvd3pdhuY59ibGd64rQ9bsQa1zeFUPUIIV+JCcF+/sQY7uVel/SlBg1aEsqGsYQ67YlRlun0Lb7lN8b+DawKd9QNbO4a+qeZpTZHdiB+iTRp2KNw6FYIvN81Pye7FPHv2bn9X3gO8A/AI8HPuV4nm3rj52muoGbdjtgU/ZzdsM6kd8CtzrWI+2mM1Sf6+LaiZm+fA7a214+N52h+lzb8jGzB/byh0k3MK4atW2XpJGRSluWsr3PBk7CzvfXHuVjbefa+mAq/VOscXkXsdlQNUilH0nF/j7E2m6N6Z4oVg1C+90siCXWHZqtU2nbm5bfG4sTt9D3zOK6pxlV5LMe6ox/NPbWy0uwXGz55x2FYxawnBy7VZT/MpYP6UTMgQ4AXgL83LG8S/2p4qMbuGm3b7Y/P+bk7N/vLRyzwGS7Q712deWl3dak4nMu106q9Olz0N5n1F5OZsg+51I+VVYBvwLumrDfVaO2fZo0Mrpqy0D2nsTNwKXAao+yMbdzbX0whf4p5ri8i7h+qBqk0o+kYH8fYm63xnJPFLMGs/C70Mwq1l1gehs/NFvPym6zjFlXYi+4O6e4cW5xcXHCuXXCyuzEdmbyRdonJwGHZeexqebYPsqninRLF2mXJqnr1tVvpEjq2o1Vt09gT9d9Bs6aIo1mi+w9mQOBDwPPblhO7VxYZP/wSIP0kGbhkQZhmVWsq/tIP2Ky28ewGc/vK27se2Zx3dOMvnkJ8Fb8Dde2fKpIt3SRdmmSum5d/UaKpK7d2HTbDnvSfxhw4YzqlEazRfaezGXAErBfw3Jq58Ii+4dHGqSHNAuPNAjDrGNd3Uf6EYvddgT2Bz5S3tH3zOJZztwR3SHd0kXapYl0SxdplxYnAkcB5wPHAPeFPR0hZs5jgM8Br8D95kLtXFhk//BIg/SQZuGRBmFQrCuacApwLnBFeUdfM4tDzNwR7ZFu6SLt0kS6pYu0S5P3A7tiue4UPIsxcge2bPEIh2PVzoVF9g+PNEgPaRYeaRAWxbrClb2A66kYKIb+BovfDpwHfBVY11MdonukW7pIuzSRbuki7YQQqXIt9uKTOtTOhUX2D480SA9pFh5pIEQa3AR8dtLOvtNQCCGEEEIIIYQQQgghhEiAvl9wJ4QQQgghhBBCCCGEECIBNFgshBBCCCGEEEIIIYQQQoPFQgghhBBCCCGEEEIIIeD/ARLG5p9xBAU8AAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$\\displaystyle C r_{j}^{4} {\\gamma}_{2,0,2} + C r_{j}^{3} {\\gamma}_{1,0,2} + C r_{j}^{3} {\\gamma}_{2,0,1} + C r_{j}^{2} {\\gamma}_{0,0,2} + C r_{j}^{2} {\\gamma}_{2,0,0} + C r_{j} {\\gamma}_{1,0,0} + C {\\gamma}_{0,0,0} - L \\left(r_{j}^{4} {\\gamma}_{2,1,2} + r_{j}^{3} {\\gamma}_{1,1,2} + r_{j}^{2} {\\gamma}_{1,0,2} - 2 r_{j}^{2} {\\gamma}_{2,0,1} + r_{j}^{2} {\\gamma}_{2,1,0} + r_{j} {\\gamma}_{1,1,0} + {\\gamma}_{1,0,0}\\right)$"
+      ],
+      "text/plain": [
+       "     4                       3                       3                       2\n",
+       "C⋅r_j ⋅gamma[2, 0, 2] + C⋅r_j ⋅gamma[1, 0, 2] + C⋅r_j ⋅gamma[2, 0, 1] + C⋅r_j \n",
+       "\n",
+       "                       2                                                      \n",
+       "⋅gamma[0, 0, 2] + C⋅r_j ⋅gamma[2, 0, 0] + C⋅r_j⋅gamma[1, 0, 0] + C⋅gamma[0, 0,\n",
+       "\n",
+       "        ⎛   4                     3                     2                     \n",
+       " 0] - L⋅⎝r_j ⋅gamma[2, 1, 2] + r_j ⋅gamma[1, 1, 2] + r_j ⋅gamma[1, 0, 2] - 2⋅r\n",
+       "\n",
+       "  2                     2                                                     \n",
+       "_j ⋅gamma[2, 0, 1] + r_j ⋅gamma[2, 1, 0] + r_j⋅gamma[1, 1, 0] + gamma[1, 0, 0]\n",
+       "\n",
+       "⎞\n",
+       "⎠"
+      ]
+     },
+     "execution_count": 144,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Remove the (-L)**(C-1) * (r_j -L)**C part\n",
+    "ftmp_en3 = ftmp_en3.subs(sym_subs).args[2]\n",
+    "ftmp_en3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 145,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABWwAAAAfCAYAAABzh4TgAAAABHNCSVQICAgIfAhkiAAAEVNJREFUeJztnX2sJ1V5xz93Qem6EGnxBVts1wawIOrapYbaQi8iaDWxFKRNVehPEEUklIgtYjW5GCsYglJqUWkjW7VGUrdKUKhbXqyggrARwborarxVWwoFfClUu6yufzwz3tm585vfmZkz55z5zfeT/DJ3532f53yfZ87LnFlYWlpCCCGEEEIIIYQQQgghRHzWxL4BIRLizcAu4D2xb0SIOeD1wF3AD7PfF4CXRL0jIYRozvnA7Vgc+x/gGuCwqHckhBBCCCHmHjXYCmEcAZyONTAJIbrzXeBNwEbgcOBG4BPAs2LelBBCNGQRuBx4HvB8YCdwPfBLEe9JCCGEEELMOWqwFQIeD/wjcBrwvRn7fhC4H1jX900JUcNGbDT4abFvpIargWuBrwP3AH8J/C/w2zXHSF9CjIshxLIXAlcCXwHuBk4Gngj8Ts0ximVCCCHGwBDyeB3K1yIFpuqorsH2IOBCYCv2Ctij2fJ64Ezgcd5vc3zciDnmyNg3MnKuAD6G+aOOw4FXAhcBj9TsJ+2EYcz62YqNVn07sHfke3FhD+BPsHv9/JR9XPQlbYVF9g6DYtlwYhnAPtjz80NTtutZIU1k7zCMOZ71zX7Aq4GPA98AfgT8ALgFq+RPq9fLJ2EYq52HmMdzlK/TYqwaghodLVR8dGwBuAA4D3gsVrm+C0sIvwYch70GdgvjNKYvFrDRnPtgIzwfjns7o+V04Axs1N8O4DPYKJqzKvbdAjwXeAr2kFRG2gmH9GNl8TZs5Oo7It/LNJ6JzV37C9jo2ldgo26rqNOXtBUW2TscimXDiGVFrgIOxip6P6nYrmeFtJC9w6F41i9nAO8F7gVuAr4NPBk4AbP3ZuAkrMEjRz4Jw9jtPLQ8nqN8nQ5j1xBM0dGeFTt+AJgAXwVeDny5tH0t8AbgwD7uckQchBXGbYyzQLoywV5FPBprTPXJ0zExHIk11tZxMPAC4O+pDugg7YRE+oEvAtuB1wLvpLrhoI4J/Wkr52vABmBf4ETstaNFrFOkyCx9SVvNmNDNt7J3OBTLuscyCBPPAC4GjsKeG6ruU88KfpnQ3a+ydzgUz2YzoX2Zvgd4KfAp4KeF9W/G4uiJWOPt5sI2+SQMY7fzkPJ4jvJ1WoxdQzBFR+VXJ96AFcpt2EeYyoUSrED/FTb8+wRsSPhtWC9DFRdgPX2v6XL3c8jGbLnVYV/ZuT1HY3a5GOu1uBp7jXEXFqSfgDUe7cx+v4eV7Z3AXoXznIr1/Fw15TpNtQPyaxdc9TPvNv4o8KtYWQ5Nnbaeke2zA3tt7w7sS+t3AudUnKtOX9JWWGTvsCiWGanHMoBLgFOAY7C4VoWeFdJC9g6L4lm/3Ahcw+6NtQD/Dbwv+3uxtE31zTCo7MfN4+Cey3OUr9NCGjJW6ajYYPsUrMDtBP4Ie321jh8B9wH/ioniLyr2+fVs/e1Y74VY4fBseYfDvrJze34zWx4G3Iw95Lwf+AgmiGdiIwDz3x3Z+g3sPur2BVgvx60V12ijHZBfu+Cqn3m38eey5bERrl2nre1TjlmDTY9QZpq+pK2wyN7hUSwzUo9ll2Hz3B2NjbSZhp4V0kH2Do/iWTwezZY7S+tV3wyDyn7cPA7N6yXK12khDRmrdFScEuEcrCKdfwnX9YR/CDzIipGLXIbN93Emq3sDx06TBCo7tycP3r+LjZ4tB+UHS/9+BOuNK2pgHdaAu43qCcnbaAfk1y646mfebXx7tjwqwrVnaesi7LW972DzEb0cG/nxktJ+dfqStsIie4dHscxIOZZdjjXWHo89H+yfrX+Y3V/b07NCWsje4VE8i8Oe2Oh/gH8pbVN9Mwwq+3HzOMzO5UWUr9NDGjJW6ag4wvb4bPmhhif9f2y0wSGl9S/FKuZX4JYkxsQa4DlYr86djsfIzu3Ig/efUR+46/gV7Cv3907Z3lY7IL+2oal+5tnGPwB+jL06EZpZ2tof+DA2j+0NwG8Bvw9cV9qvTl/SVlhk77Aolq2Qcix7HdbpdAMWp/LfG0v76VkhLWTvsCiexeMibFThtcCnC+tV3wyDyr4RM49Dszq/8nVaSEMrrNJR3mC7Nzbx8i5sPoimbMceZg/I/r0WuBR4AJsIfR5Yxuzj+vtwzbkOxuy1nepenWnMu52XWW3HK7NtN1Vs2zTjfOswW9/vsG/OInBWad1+2fJ7Fft31Q6M069ttQPt9DPPNn4Im4u5jmXCa2uCzS20F/Ak7NWjT1fsN01f0pYby/jxreztxjJxnwXm2cYusQz8xjOXWLYw5bdU2k/PCt1Yxp9fZe/ZLKNns75Zxu+zVxVnA+ditjy5tE31zWqWUdnvixh5HNxy+YXAluxv5etuLCMN9cluOsqnRHhitvwh8H8tTprPC3Io8F3s4zJPA05jtRDOBP4cmxvk37Eh5zc3uFas47+JtXa78l8125q8nlLExc5HYf+/jdj/8STgYw2vA3HsfCn2NfkiG4A/AP4BCw5FZvXAPBvrlCh/TbUp+bw0VXNvdtUOuOvnfGyi7adjPUu3ZuuavKrRxa9tr+9TO9BOP6Fs3FV/ba6/lulfN81JVVswXV8hteUjbsbQFvjz7ZhiWRd/x34WCFWmU41l4DeehYhlEFZfXZ/fup6jrb59+jWUvWPHsi7nGNKz2VBztO9nrzKvB/4aG2l2DFbJL9JnfdNH2Yc4uXxIZT92vQSa+ShGHge3XP5ObAQnpJOvY8e2tscPSUOxn4ehuY1301HeYPtIYeMerBRmV4oG+yY20e+trPSU5PwxlljOBG7BXjO7Ljvu2w7XiXn8MQ7ndyUvlC5f7CziYud12FcMrwQ2t7y/WHa+tGLdBAvem4DPOFy7SP5qRF3v2IWYAI+r2ef+bLlfxbau2gF3/Sxic+ndjo3ueRtwfXZc+SGtiq5+bXt9n9qBdvoJZeOu+mt6/TXYA8+3Zpw3VW3BdH2F1FZXv8XSFvjz7ZhiWRd/x34WCFWmU41l4DeehYhlEE5fXbXh4xyLtNO3T7+GsvcicWNZl3MM6dlsqDna97NXkXOAd2MNd8ewEn+K9FnfXKRb2Yd4uXxIZX+RuPWSJj6KlcfBLZd/v/B3Cvka4sc25Y/ZhPbRKh0tLC0t5X9/C1iPvbZ6Q81F17C65+JQrLX474BfBl6EzVf4pdJ+twF3AacX1n0da6U+v+aaqRzvi5uxCbGfB3yhwXGuds7ZRbtegJTsPMEEcjTNg/cHgFdhQWBaANgXC8R1X39cwL5IuMBKr1uRLtqB5n7N2Rub5+R44JoZ+4L/8t/0+r5oo59QNi7SVn9Nrn8INrLin4ETG557QnxtQb2+Ymirjd9S09aEdr4dYyzzodO2hIplXf+PqccyaF/mQ8UyCKMvH9pIKZ5NaJ+nYsSzGLFsyHWbMeboCe3LdM552Ly1d2JfEn9gyn6h6pvQzibK5enXS5r4KFYeh9m5fF9s1OUGrPEthXxdJkZsU/5oRggfrdJR8aNjeU/H5cBvVBy8gH0w5qMV276BPcyehE30+15WG+ux2AiFLaX1WzDnzCL28b5oMwF8jouduzIvdgbrbdsB3F2zz/eZXQnbBXwWm0vkwIrtXbQD7f26D1aeXHpY+/BLk+v7oq1+Qti4D2Zd/4hseVOY2/k5vrQF9fqKpa0mzIu2YLyxLAahY1lsxh7LoH99+dCG4tkKbbQWOpalEg9TjmfzVKYB3oo11m7FRrlNa6wNXd9sapNUym5X5rle0tRHsfI4zM7lG4BHgW3Zv2Pnax/MS5tNyvmjK21svEpHexY2XgY8CzgVK+xbgHuwwv1UrNX7AOAjFSfegfVEHIgNMX9rxT5PwIaV31dafx/WezGL2Mf74hBsaPUjwN9M2ecB4E0V613s3JV5sfNeWM/LXZjdqij3ttWxGevleCEWIIp00Q609+ulWGCb9SVM6McvTa7vi7b6CWHjPph1/eOwZHV1sDvyry2Yrq9Y2mrCvGgLxhvLYhA6lsVm7LEM+teXD20onq3QRmuhY1kq8TDleDZPZfpPsVfif4KNSDu7Yp9l7JXy0PXNpjZJpex2ZZ7rJU19FCOPg1su34A11ha3p1i3b8K8tNmknD+60sbGq3RUbLDdhU3Suxkbsvtc7DWLh4F7seHJnwI+OeXk2zGDncfuc4SU2VX690LFujpiH9+VjdlyHWbvKqq+pJ7jaueuDN3OhwGPoX4ulHJvWx2bMXGdAvxtaVtX7UBzv16MTYJ9JM3m1vHll7bX70oX/YSysS9mXf/x2CtRnwS+E/C+fGsLpusrhrbaMnRtwThjWSxCxrLYKJYZofTlQxuKZ0YTrcWMZbHj4RDi2TyU6adlyz2wOWyr+DeswTZkfbOLTWKX3a6MoV7i4qNYeRzcc3l59GYK+doHQ2+zGUL+6IqrjSt1tGfFjtdmv6b8IjaHxz9N2f4AFlz2L61/EqtbnVM83hcfzH5tmWXnrqRm503ZrylbMTHUUdXbNo0d2ITR78CG7VcNuW+rHWjm10uAV2Jz/JR7BKfh0y9tru+LLvrp28Y+cbn+KdjXTS9peY1NpKEtmK2vUNpqQ4ra2kQ73+aMJZbFJFQsi02IWAbtynyMWAb96cuHNlKLZ5voFssgTDyLFctSiYcpx7N5KtNL2c+FUPXNtjZJpex2ZZ7rJU18FCuPg1sufzbwodK6lOr2bUitzaYtKeePrjS1caWO1lTs2IYFTAhfY+XLemV2YII6trT+WODzDteIfXwKuNi5K2Oyc1VvWx3vxr7m9zbP99HEr5exkrC/2uAavvzS9vqxCWFjX7hcfy02Uflm7LW41GiqLehHX0OImTmxy50PhhTLhkqIMu0LxTK/zPK9D20onq3gqrWYsWzo8VA5Ok36Lvsw/LLblSHUS1x9lHoefww2ZULVtEYp1O3bMqY2myqG8DzcxMZTdVQ1wrYNB2FfLZw10e+7sN6NLwKfA16LfdXtfY7XiX18bFzsvDe7T569HqtwPIQFJBfGYueq3rY6fgycjCXMfK4VH7jq53IsYR+P+TPvrXk4+82iq1+6Xj8moWzcVX+u118PXEH3kUd90VRb0I++XP3e1W9j1laRocQyH3kyFqHKtGKZkUosAzff+3j+UjwzXOwdO5b5OkcslKPTJETZB+XyIdRLXHy0nrTz+KHYx5+qOl9j1+1jxzblj9mE8tF6pujI1wjb52TLWQa7Cptz5y2YaI4EXgz8R2GfCTanw/pIx6eMi50Pz7bn+1yc/V3sOZow3UYw205dj0+But62Oj4LXIDfnhxX/bwO+zroDdj8OfnvjYV9JvSnH5frp0ooG3fVn6uNt2GvxS3P+P/EoK22wL++XP3e1W9j1laRocQyF3+nSqgyrViWViwDN9931YbLOWYdP6Z4FjuWuZ4jVXzFswndbVR3jnkp066EKPvQPdaMIZfHrpe4aCflPA7WuPafwINTtses28eufyh/GBPiaghqdLSwtLRUcd6oXAC8DBvVsDPC8WNANrZ7vxP7et+0AD5E5Nv+kY3rkbb6OX5syN79IxvXo1jWz/FjQ/buHx82kp39o7IfBtm5nvdgIxpPiH0jLZF/+ydpG/saYeuTFwNn0f4/2/X4MSAbz+5tGyrybf/IxvVIW/0cPzZk7/6RjetRLOvn+LEhe/ePDxvJzv5R2Q+D7FzNWmx05MuA6yLfSxfk3/5J2sYpjrAVIgRD720TIlWkLSHEPKBYJoQQQgyTtwBnANcAZwOPxr0dIdqR4ghbIfpkXnrbhEgNaUsIMQ8olgkhhBDD5u3AAdg8wGqsFYNFDbZibJwLfAL4OOl+zVKIISJtCSHmAcUyIYQQQggRHU2JIIQQQgghhBBCCCGEEImgEbZCCCGEEEIIIYQQQgiRCGqwFUIIIYQQQgghhBBCiERQg60QQgghhBBCCCGEEEIkws8AdoFxxF4w3HwAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$\\displaystyle C {\\gamma}_{0,0,0} - L {\\gamma}_{1,0,0} + r_{j}^{4} \\left(C {\\gamma}_{2,0,2} - L {\\gamma}_{2,1,2}\\right) + r_{j}^{3} \\left(C {\\gamma}_{1,0,2} + C {\\gamma}_{2,0,1} - L {\\gamma}_{1,1,2}\\right) + r_{j}^{2} \\left(C {\\gamma}_{0,0,2} + C {\\gamma}_{2,0,0} - L {\\gamma}_{1,0,2} + 2 L {\\gamma}_{2,0,1} - L {\\gamma}_{2,1,0}\\right) + r_{j} \\left(C {\\gamma}_{1,0,0} - L {\\gamma}_{1,1,0}\\right)$"
+      ],
+      "text/plain": [
+       "                                         4                                    \n",
+       "C⋅gamma[0, 0, 0] - L⋅gamma[1, 0, 0] + r_j ⋅(C⋅gamma[2, 0, 2] - L⋅gamma[2, 1, 2\n",
+       "\n",
+       "        3                                                               2     \n",
+       "]) + r_j ⋅(C⋅gamma[1, 0, 2] + C⋅gamma[2, 0, 1] - L⋅gamma[1, 1, 2]) + r_j ⋅(C⋅g\n",
+       "\n",
+       "                                                                              \n",
+       "amma[0, 0, 2] + C⋅gamma[2, 0, 0] - L⋅gamma[1, 0, 2] + 2⋅L⋅gamma[2, 0, 1] - L⋅g\n",
+       "\n",
+       "                                                          \n",
+       "amma[2, 1, 0]) + r_j⋅(C⋅gamma[1, 0, 0] - L⋅gamma[1, 1, 0])"
+      ]
+     },
+     "execution_count": 145,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Powers of r_j\n",
+    "collect(expand(ftmp_en3),rj)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 146,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABkYAAAAfCAYAAACyGnH4AAAABHNCSVQICAgIfAhkiAAAGj5JREFUeJztnXm8HUWVx78vIBCTSBBEWRORZWDAhISJDggGA7jgMGEbRxR8isiiAwhoRLawKCgCEREFRwno8AE1KsM2IoggAhIQBJRF/PhAMRB2xIU188evK7dfv+6+vd2u7nvP9/N5n5t03+6ue6rOqeo6dU4NzZ8/H8MwDMMwDMMwDMMwDMMwDMMwjEFgnO8CVES//A7DyMJngWXAWb4LYhiGkZOPA3cCzwZ/NwE7ey2RYRiGYRhZORJYjPrwx4BLgc29lsgwDMMwDCOZVJ9BPzgUNgY+6LsQhlETbwX2QxOLhmEYbeNPwGeAmcBWwE+BHwFv9lkowzAMwzAyMRs4G9gaeAfwEnA18FqPZTIMwzAMw0hiGrB90kkfjpHD0Gr3vSq41yTgdOC7CecvAJYCEyp4lmEUZSZq8/uWvM+qwP8E93mqbKEqwPTLMAaLKmzZJcAVwO+A+4GjgL8A/1q6dMUxW2YYhmEMAlX04+8EzgPuBu4C9gZeB2xTunTFsX7caAJVvfMbhuGf9ZE+/8B3QUrg5t7f77sgDeB2YFcUWDGGOMfIT5Dwwn9PopDZfYGhkgWaEXz+quR9AE4DFgD/iDm3FYokOQX4a8o9NgJOBm5D4cAvBp9XAwcBr66gnIZWBS8DtvVdEA/chlZEnwRMLHGfc4HvI1n6xvSrmZi862FQ7VlVtsyxAhqoTQRurOB+RTBb1kxM3vUwqLasDlYHPgr8EHgA+DvwDHADep9KW5xm9dJ7BlXGVffjoIWK49B8gQ+sH28Wg6pb0Bv9qhvTk3oYZD1pC1XOW/tiq+DzNq+lyEacHyL6d3To+5OBp4En0Dgkyjg0d7oM+O/g2InAN4gZgw/FbL7+RPCQk4KbjAM2BPYAXhXc7Ng8vzDCb4H10Or3V0rcZyZwPsk5Ta8CZgFroZeRKEPA8cA8YCU0KXMnemmZAuyEQoJvwAxWWYZQhMMkVO/P+S2OF2YBv0Sroz9f4Pr9gAPQquoXgJ+hlVqfqKh8eTH9ahYm7/oYdHtW1pYBbIH2FlkFRYt8AEWR+MBsWbMwedfHoNuyXnMA8DVgCXAt8BDwemA3JO9FwJ7oXSuM1UvvGXQZV9GPh7kYrcDcCni5gvvlxfrx5jDougXV61ddmJ7Uh+lJOzgBOAZ4D3Cl57IUZX3kzLyPsePNpvEE8Brgcynf+S7yJzhcHX0WOXTDnIX2Nr0MmEtnfHIOcD3KxLOcFSMXvwkZvN8Cx0XOXRZcvD/FHSMTgE2QoS3jFAF5iy5IOLcxsAPyDMUNkAC+BQyj37oX8OvI+fEo9GjDkuU0tPJgVeAeBtfw3wLci/TnC+R7cdgEDay2RU6RsgyjEPjtkYMlL6Zf1TJMufoAk3edDLo9K2PLHPcB09EijN1RXz4bOXvzMIzZsiYxjNmyNjHotiwLwxRv0/cDuwCXM/qd57PIju6OnCSLItdZvfSeQZdxFf2441RgO/SOUvQ+wxTXM+vHm8Wg6xZUq19ZGcbGX23C9KQdzAw+2xwx8pDvAmTE+SFuB+bnuO4M4BDgcOArdPTpKOQUuRl4H6Pt8PnAt5GT5UV3MBpC4kJtfhnz0OuCz9Ujx4eQEb0OeXn+jn7Qh2LuMT14pgvlORx5rg6P+S5oQvh55NEJsy562fhewnUfCcp1ccL5w4Iy34M2s44aftDv+BwKGQS9vLyIZDMl4b7Ho9/zsYTzg4ozKt1CuPpdxhchr+0OMee2R7/rVLTS5BIUkr4s+P4aaNLwpeDv7ahtvgSs3OuCRzD9ahYm73oxe1bclv1z8J0XUGqZW4EjgTuAQ3tb5FjMljULk3e9mC3rLT8FLmXsQrBHgK8H/54dc53VS+8xGZfvx0EprfcB5qA+3QfWjzcL0y1RhX7VielJvZieZKfX+rIimli/E7XxB4FPo35lBvAw8Gjo+3nmvsPl/1Jwvx8F5X8GpVp9Q/C9zYAL0V5Zz6CghPVj7rcXCla4H2VdeAptefHhlGd/MXJ8x+D4ySj70oXBb3wOBTC8JeG39BLnh1ic87qnkENkdeQIAcniJLQQ873A3yLX3IjmT3cLH0xyjNwS89BNgs8HQ8fGA/+HPNSTkfflPFTBC9GqqDBRr9sNwedbY54H+pErMDZd0PtQg/lDwnU7IK/QzTHn1kJG/SXgP1CDSsOtPnkU5T2bhZQlygbB8cV0cpgZwrWrW7t8r99l/Ivgc8eYcy6H4ebAz9GL9DnIUF2EUs9MD/3dGhyfTjVRJHkw/WoOJu/6MXtW3Jbdm3C/cSitVt2YLWsOJu/6MVvmD7dC7aWYc1YvvcdkXL4fPxPt67E9o9Na1I31483CdEtUPU7uJaYn9WN6kp1e6stKKJXzAtSPnAVcg5xN56I57XC0SN6573D5N0Zz3y8D30SRHHNRpNa/ofn3icE97wd2Zmx2pEnB+Q2QLM5CG8O/MbjPvIRn3x45vmWoTItDz70Ope3/X+L37OglRR0jAKcjp84RyIadi9LYvgs5r+L4FZEN6aOptJIcI5NRKCCMrqALUb7BaA7F41BDPRbl130qOB7dwOZXyLjGeaX2RJ3JmciDF2YHxlawYwKaLL6H+A3YDkUTMOeRL23HL9Au9k/QkVOYM5FyHUT5NGH9Rlbj3+8ydoq+Xcw5pxtvQ9Eg0QF+VKn/irzNeVPPlMX0q1mYvOvH7Fk5W3YKSi3zRzTo2gutmt658lKmY7asWZi868dsmR9WRKvsQS/YUaxeeo/JuFw/fjZyisxF7yJuxetz1JsWxvrx5mG6JcroV92YntSP6Ul2eqkvX0XzzcfS2V8b5ORw2ZLCjpG8c9/QKf8sFAzg5rVPQM6RnZCjYke0/yaoTh9A9mMV4B/B8WVor+5HIr/jaORM+TCdOfvws6OpwNzxbYFtIucXoUiK6cj5EsehyD+QlTtQpEwarn1vjbJDxXEq8X39k8hJ9BkUPfos8G5gpEuZDkGLM1+B0Y6RITreo91QqqoVUQjPzijn1+VoUgMUljIXpbOKbiz1GAr/2QcJ/prg+AzkCLkn+P+LqOPYDlgb+HNwfALy/Cwlfj+Tt6C8YHGsg6JMliScnxt8Jl2fxvNoVcymkeO7IBl9ne4GbtAYh9rVy6gBdqOfZfwMMmxxYXHOQB2C/wFSGqZfzcLkXS9mz0QZW/YG4DvB5zNogPhu4MfVFzMVs2XNwuRdL2bL/HEKWvl4BWPtntVL7zEZizL9+IHB5zWR48eTLzd4WawfbxamWx3a9M5velIvpif56JW+zAI+irZsODFy7no0X70pnXRnRea+oVP+YUYv9v8LmrifDnyKjlMElA3mPuQEmUDHMZK0+GAJmkd/beT4jOD7v4scd3P+H2as08TN06dlcjiU5NRucZxPumMk7IeISwkGcn7MT7nHZcgxAvAB4tMBhrkbbfS+WfDvUam0NkabAIG8YMeh0KwdUSN8PwrzeT74jstjF/ZKhXEr3FcIPldBjevXjN78xIUahtNpHYs8RfNQxxJmDWA1Rnviwrg9UOLOT0S/cxnx+6hk4V60ytV5ssaj8KvHiQ+faiMjSEZZ/76Tcq+NkbzuJd7DF0c/y/hJ1IbDTEByWoo81FmYzdgUc3GMMLa+zgvOXRtzrtvzTb/KMUJ19WHy7s4I1dkyMHsWpqgtG0aDqZWBNVEEaBanyAhmy5rECGbL6mQEs2W9ZoRqbUwcB6N9Fe8F9o45b/UylhGs7feKov34UMLf/AzPHKE6PbN+vDwj2Dt/ryiqXycDV6XcdwQbf9XJCNYH+aIKfUniv4LPuEX40JnLdo6DvHPf0Cn/H4iPEJ6C7ETcHllTkPMknDVmNeAYNDf/FJpTd+1uY+BPMc++g9HRRBOBDVG0yhUxz90g+Px9zDnHVJLHAXF/wyn3go4f4oaUe0T3OQ+zNtp3xbFZl+dBZ9ywoTsQjhhx4SsLgE9muNnbUZhK0qZBawWfDwWf04LnRb/vHCNvQTnS/il4/k3IuxRlneDz2YTnuryHcV6u14WujW7CkhWXy24z1PiORHnd9mX0wOxIFHnjNpC/OTiWJ0TxIORBXAv4DfLOJYU0RSnz/N/T8Uxm4c8p57KGCoapS8bbIfnORDLeE/h+jnIWef54Om3UMQ05KS+n+jDIBYwNdZsO/DvSr5HIuW4rF5qgX2XrDcrpFhRve1XWR13y9m3LoHidV2nLoLf2rGy7rtuemS1LJ2u9Q3n98DFWaKMtg2bYsyLXD5Itg/a36Tg+DnwZrfycg16GozR5zAzl6mUQ+nHf7yWQr47q7sehWj1rSj/u2+aVub4t7/y+x8iQX8ZF9esLjF5EHKWt4y/wO94ten2b+qA226I4qtCXJHZCTofrE85vgPZ4eTj4f965b+iU/ycx35+KHB0/oLPvnGMi8CY68+QAb0YOoNejbS8uQuPIF1Fb2IfRURLu2dGIkOnB8auQQyXKDNL38u4FTie6RXnEMRk5naYgJ9c8tNfIV0l3PDpfwtruQJxjJGnvjjCTUOhJdO8Pxwqo8SxFYUAwduN1x42oUlzEyFnB9R8nvrImBJ/RSBLH0uAzzqvkhDM+eEYRJQobpt+jqJqb6XjqHbNRDtbFyMt1AnB1cF3cy1CU96EXqIOQ9+xA4Mrg+odSrqvi+XMy3D8rrl0lGZE46pLxBKSA56F8ennJ+/xxSHmjhsaF2KWt1DgZ6dBOOcu4IObYMBo8LQR+lvN+TdCvsvVWVregeNursj7qkvds/NoyKF7nVdoy6K09K9uu67RnZsu6k7Xey+qHr7FCG20Z+LdnRa8fJFvWD206yqHAGWiCfA4d+xOlyWPmsvUyCP34bPy+l+SpozL9ODSjL29KP+7b5pW5vi3v/L7HyHllXEa/nu5SlraOv3yPd2381R3fdRSlCn2JYxWUteB24uebt0YT5lcG/y8y9w2d8sc5wWamnNuSsU6NbyObsj1jdfyEmHslbbzujse1v0nARshZFCcXR9V7jBR1jKwCXAJsgWRwIqqnI1Db+1LKtc6X4HwLhR0jzyOv3WoJ54eR1+wLdISatPnLUyiX2VZoE9Y5aNOapHIMBZ9JlbUE5XnbJObcUuRFn4oGr9HcqGGWb8QSIWyYdkAyPCimPO+M/H9vVAHbAJemPNdxGOrcvhH8/2CUh/1A5CXuRtnnV0Wa0idRl4yvpGPwipD3+Zug9htduZFmNB1FveFV0wT9KltvZXULmqFfdcnbty2D8nVeFb20Z2V/Y532zGxZh7JjhbL60Q9jhUEam1VhD6ugybasH9p0mHloX5E7UHrix1O+2+Qxc9l6GYR+3Pd7SZ46KtOPQzP68qb0475tnvUr3am7jorq12Q0NzadYqun8zJI413Tk+40Tca90peXg781E84fH3y6eesic9+Q7oSYmXLO7bfhnr8eihj5MWOdIpPp7MsRvlfS3Lu7d5pDppvTruo9Roo4RlYALkRRUueibUAAvkgnaulskiPhnC1zvoXle4yMQw3qeTobrqTxAloNsx5SzjBzkKdwBK0mccwI7v+bmPvdALwaOAe9MByd8mzn2X5NwvllyMu1BqGcYSGcl/1slLYryhBS4IsS7v8AUqQ90YZHaU6cMJOQnLOsGFoJKUs0X95VyINZhDzPr4q8m0s56pBxL+j2fBcVdW3k+AykU3el3PtplGfQN03Vr6z0QrfAX9vzIW/ftswXddsz36TVs9myanSrrH70y1gBBmNs1hR72GRb1k9tGpQL+hT0kjmHdKdIk8fMTWm7ZWmyjMuSt47K9OPQjL68Cf14Waxfaf4YuYiMi+rXdJQaJ8t8XFUMwnjX9KQ7dcp4IbLfw13uWURfstz7RbQh+TpoD+0w8+jMbzsHQZG573D549JpJmVTcteFz7lUbhsArwp9b3W0P8m6wEuMblMzgut+m1CmuOiXtDKFmUp1e4w4P8QrdB93hPkqsCtyuBwUOv4YsmVrAgekXO/2Vl+ebstFjGyKcpndhoSahaOQ1+oy4Lson940tFrmQbQqyoWorARsjrxA0RxqoPxpHwvK8EnSB5CPBp9JjhFQ6NjuQVkeiJw7E3ncPoKEfxVwf1Cu9YC3ocZ1YcK9X0BhkRsiL/sxKeUIswA11pszfHcN5AV7NHL8UcYqY1byPL8qNkXhSX8FvpLwnceBz0SO1SHjXtDt+TuhTu2S0LGVkff/TvS746h79Ug3mqhfWemFboG/tudD3r5tmS/qtme+Satns2XV6FZZ/eiXsQIMxtisKfawybasn9r0h1Bo/8sov/bBMd8ZobOhaJPHzE1pu2VpsozLkreOivbj0Ky+3Hc/XhbrV5o/Ri4i46L6NR1N8qbpX9UMwnjX9KQ7dcrYLc5Pm3cuqi9Z7g1yYpyP+pCLgEdQ1NQWwB9R2w87CPLMfWcp/4zgurgFMzPQ/kTO4fMY8FPgHSit2NUoQuXdyPn6CnKAOAeKe/YdjJbDyqgN3pVQprQoll7h/BDPIqdUEufS2b/neGB/NLZ+P2OjV09FzpJPIydidK8n6PgSlrgDzjHihJDHc3kN8pAdhzaaAynsiSifV3gVyRbIu5XkfXL5FxcD3+zy3CXImKTlNVuElHAf5E0KswxtVLQI2A+YhRryc8G9b0Ib/FyWcv97kWGaR7a8dqeiMJ9tyRd2HA2PG4o5loWizy+La1cTkMzj+HHC8bpkXBXdnr8qMBe1qz+Gjm+OdCPNAPlYPZJG0/SrCFXpFvhte3XL27ct80md9sw3afVstqx63SqrH20fK8Bgjc1828M22LJ+aNNvDD5XQGkH4riOjmOkDWNm3223LG2QcVmy1FGZfhya1Zc3pR8vi/UrzR8jZ5Vx2XFynvm4Khik8a7pSXfqkPEWaK748pT7FNWXLPcGuAClxjoETa4/ibIYHQD8EG3M/mDo+3nmvruVfwpyJMVt/O6cF7cxeuzwn8BpdFKT3YVSl90F7MHo1Fju2dG5d3c8KTXZTKT3v0s43wucTryGTjqsKK+g3w6qn2NRFM4udJxBYZYih8jhyIESty+TixhZvqDCOUYuCP7ych3yXHXjNkL5u2L4FPrBSRuuR1mMGkwSL6CQps+jcLW4ULMrgr8irIbK+70M3z0N+CDaKCe6kiWJx5EivCFyfE3GemF78fyqKNquoPcyrpIsz98HbRB0WuR4N92A6lePLKTzIl6EJulXXqrULaim7S2kXH1APfL2bct8U5c98023ejZblp1u9V5WP5o2VlhIO2wZ+LFnTbGHTbZl/dSm5wd/WWnymLkpbbcsTZZxWfLUUZl+HJrVl/vux8ti/Urzx8h5ZVxGv6ahTZbzspBmj798t3PTk+7UJePJKELpNBR5mEQRfcl6b8eXg78oSftnZJ37hvTyP5hy7nlGp8tyPIZsSxzReyU9u5tM0+bXe0Venfh68NeNI4K/JDZDwRbLU42NS/5ubeyFcrt9DTk8snAtnY1jkjgDeAiFsVfJEFLC+wjlJEvgTDoD42h+tzReQA13x8jxHYEbc9yn6PN9U4eMqyLL88ejDacWoZCvvPhYPdKNJuhXEarSLfDf9qogq7x927I20+s2XSXd6tlsWXay1HtZ/Rj0sUKYNozN2m4P67Bl1qbz04a233ba8F6StY7K9uPQvL68re8kYP1KG8bIeWRcRr9ehSbrfKeny0sbxrumJ92pS8bboojD04sVczlx+lLVvY3+Z0sUsbM81diKyd/tKesjh8ibkOfrNygHWFYuQrnF1qaTayzKP4C90cDU5fKrgo1QHrRuGx6djQbGc1FolvOePhf8deN05AG9Be3Bsj/6vVk8ZFU83yd1yXgiozfrm4oG+0+iAXY3sj5/KsqLtzDDPeMounqkl/jUr7L1Vla3oN36FSaLvH3bMihf5z7Jas/K/sY67NlUzJZlJWu9l9WPQR4rhGnL2KwKe+iLumyZtel8tKXtD0I/7vu9JEsdTaVcPw7N68t99+O+bZ71K92pq46mUly/NkP78jbJ6ZiFtox3TU+6U4eML0URVWWJ05eq7m30P1sif8JyfEWMvAtteLMH2pRqJ+BvOa6/H21As1uX712PfnCVnlUXqdLNMB0ITEL56JaE/sIhPcModdjUmOsvRjmJj0YKvy3wHkbnuku7Psvzm0pdMt4qeIZ7zqnBv8MrjtKuzyrje1A6hZEuvyeOJq8e8aVfZeutrG5Bu/UrTBZ5+7ZlkK3Om0pWe9btNw5TXkZp98hSz2bLspO13svqxyCPFcK0ZWyW5fqmUpUtA2vTVdKWtj8I/bjv95IsdVSmH4fm9uU++3HfNs/6FTGMX92Ccvo1HXgY7W3QJtoy3jU9EcP0h4zbqi+Gf6ahPU2+Hz44NH/+fC+lqYDtgS8C/+K7ICU4HjmHphEK46nx+kGg7TKehjqWNTDDn4e213vbMHn3nipk5FPOZsuKY/pVLybv3mMybiZWL72n7TK2vrwYba/3NtB2GZ+FVtd3W/jbz7S9DttAv8jY9MUoyhkoiurE8MEm7DFSlGuRN36W53KU4T3AJyhuVMpePwi0XcbmDS9G2+u9bZi8e08VMvIpZ7NlxTH9qheTd+8xGTcTq5fe03YZW19ejLbXextoq4zHo5X+ewBX1vzsptHWOmwTbZex6YtRhknANsCXoifaHDEC8DrgW8CumAE0+hPzhhuG0Q+YLTMMwzCMdmN9uWFUy9HAAWh/hIPR5tGGYcRj+mKUYQGwCPh59ESbI0YAHkPhXHv5LohhVIx5ww3D6AfMlhmGYRhGu7G+3DB6w0nAumiPIpvkNYx0TF+MorwZuJsYpwjAivWWpSfcCtzluxCGUTGHI2/4D4GFfotiGIZRGLNlhmEYhtFurC83DMMwDKOt3AfcmXSy7am0DMMwDMMwDMMwDMMwDMMwDMMwMtP2VFqGYRiGYRiGYRiGYRiGYRiGYRiZMceIYRiGYRiGYRiGYRiGYRiGYRgDgzlGDMMwDMMwDMMwDMMwDMMwDMMYGP4fQLrglZyXFYUAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$\\displaystyle \\operatorname{Poly}{\\left( \\left(C {\\gamma}_{2,0,2} - L {\\gamma}_{2,1,2}\\right) r_{j}^{4} + \\left(C {\\gamma}_{1,0,2} + C {\\gamma}_{2,0,1} - L {\\gamma}_{1,1,2}\\right) r_{j}^{3} + \\left(C {\\gamma}_{0,0,2} + C {\\gamma}_{2,0,0} - L {\\gamma}_{1,0,2} + 2 L {\\gamma}_{2,0,1} - L {\\gamma}_{2,1,0}\\right) r_{j}^{2} + \\left(C {\\gamma}_{1,0,0} - L {\\gamma}_{1,1,0}\\right) r_{j} + C {\\gamma}_{0,0,0} - L {\\gamma}_{1,0,0}, r_{j}, domain=EX \\right)}$"
+      ],
+      "text/plain": [
+       "Poly((C*gamma[2, 0, 2] - L*gamma[2, 1, 2])*r_j**4 + (C*gamma[1, 0, 2] + C*gamm\n",
+       "a[2, 0, 1] - L*gamma[1, 1, 2])*r_j**3 + (C*gamma[0, 0, 2] + C*gamma[2, 0, 0] -\n",
+       " L*gamma[1, 0, 2] + 2*L*gamma[2, 0, 1] - L*gamma[2, 1, 0])*r_j**2 + (C*gamma[1\n",
+       ", 0, 0] - L*gamma[1, 1, 0])*r_j + C*gamma[0, 0, 0] - L*gamma[1, 0, 0], r_j, do\n",
+       "main='EX')"
+      ]
+     },
+     "execution_count": 146,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Convert to polynomial to extract coefficients\n",
+    "pe3 = poly(ftmp_en3,rj)\n",
+    "pe3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 114,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABNkAAAAZCAYAAAAMj/hAAAAABHNCSVQICAgIfAhkiAAAC7JJREFUeJztnXusHUUdxz+3kIaXAbG+NVIDRHxCJMQYK5cQjI8EQQUT4+NGfFETRTSgRuItidGEiAVJIcZItcZotPGPCioivURACzYiKlTEeCGEZ30ApWhbqH/89qR7T/ecM7szOzN79vtJTs7t2Z2d3e98+905c2Z3Z+bn5xFCCCGEEEIIIYQQQjRnWenvWWBv6bUtxQ4JIYQQQgghhBBCCJEpK1g6frZ3sGBZxco3AmuAK8Zs8Bjgq8BW4FFgd/F+PbAaOCTEXgtuwBprVeodmRLk27hI7zgoJ8Ihz8ZFesdBGdEezwE+AvwUuAd4CngMuAk4h+p+9gC1S/tI43Aor+Mgz4ZFvo1DX327Exs3WwPcW14wU7pcdBbYXKw0TzUzxfILgeXALcAdWIfiZcBbgCOxzkXfRA7NDPBv4FnA4cCOtLvTaeTbuEjveCgnwiDPxkV6x0MZ0S6fAK4EHsT60PcBzwfehem9ETiL0q/bBWqX9pHGYVBex0OeDYd8Gw/51lgATsb04MCahb8DzAF3Au8D/ji0/GDgfOBonz0UgI28Hw7cRX/NGgr51p054GrgFCwsmiC946GcCIM8684cyoguoYyYzBzNPX03cDpwDfBM6fMvArcC78YG3DYOlVO7tI80DoPyOh7ybDjk23jItxWMm8Y+zPmYWe8C3sD+ZgWbJv8VbPolWMdiN7AFGzWuYg32C9/HauxLH3h98b51wnrSeDzybVykd1yUE/7Is3GR3nFRRrTLDcAmlg6wATwEXFX8PVtRTu3SPtLYH+V1XOTZMMi3cZFvK3AdZHshZsQ9wNnAExPWf6p4fxj4FXAScEHFei8vPr8N+LbjvvSFE4v3309YTxqPRr6Ni/SOj3LCD3k2LtI7PsqIdOwu3vdULFO7tI809kN5HR951h/5Nj7ybQWug2znAQcBG4A/19j+zcCZwJPsa4Ayl2PXSa9m/18B+46rYaXxaOTbuEjv+Cgn/JBn4yK946OMSMOBwAeLv39RsVzt0j7S2A/ldXzkWX/k2/jItxW4DrKdUbxvaFDH/7DroY8b+vx04B3At5jcKH1jGXAC8DRwu8P60rga+TYu0jsuygl/5Nm4SO+4KCPS8TXg1cC1wC+Hlqld2kca+6O8jos8Gwb5Ni7y7QhcBtkOA47Fro/d0rCebdgTJ15S/PtgYC2wHbs57IAvYFMEH8cer7sJ66TUYTXwD+C/2LXBdZ4Y4lP/IqaR6+v7Y7Z1LKbXNmy014VYGr+5KPMAdhzvqVE2RP2uxPKtrx4DUvh2kf19eXWxbHPFsvVjthVL79QZAc3bfJFwGQHt5oSvr7uQEzHPbeDvO2VEd/oSTcsv0p+MgO57ehSfAj6LafmBiuU59/HAr136cH5M3Y8G/3yaRMy8zkGPpuUX6cZ3v9R9OmjfsxDXtyGOR/0MYxqzwenpos8t3h8HdtbcsQHbivdXAvdjJ6iVwDnYI18HzALrsJPXDHAxcH1R7l8O9bwXuAwT5CbgXODnRfn7HMr71P93rAFceWDMMtdpl2ViaXwodgPJq9n/aVku+NbvSizf+uoB6Xy7Fjhi6LPjgXcC38WCuMy4Xyhi6T1L2oyA5m0eMiOg3Zzw9XUXciLmuc3Xd8oIoyt9iabl+5QR0+DpKj6JHdedwKkj9iXnPp5vu/Th/DhL2n50iH7MJGLmdWo9fMp35btf6j5dDM9CPN+GOB71M6Y7G5iZn58f/D2L/Yq3BpgvrfM87EZ1u4BDsOmAdRk8vvwz2IjkX4A/AG/ERiZHcRjwGDb1c5NDPVuAO4CPlj77G/ATrAHrUrf+UKwFPo39GvpNxzKxNC6zFzgL07cpbWmcwrdN9cjJt3NYmJ0CLNQolyonUmdEiP8DTYmVE77HmGtOxPSsr++UEUZX+hKh26spOWfENHh6mPOAb2D3AToVeGTEejn38UK2Sx/OjxC/Hx0jX1LldQo9lNf1yNWzEM+3IY5Hvp2+bFgATsZ+fHG6XPQR7Je95VQ/hrzMqO2VRywvw2bQrWb8SQtsKuEy3H4ZWo49Qva6oc+vwxqtCXXqD8ngUbhNR4Xb0rgN2qo/pW/rMC2+TaV36oxIScycSE0bno7lWV/fKSP20YW+RE45k2tGTIuny1yIDbDdjg3WjRpgg3z7eDl515dcNfYlVhv1pQ+dk+dzzWtfYmocw7chjke+NaY6G1wffLC2eF8HvKJi+QzwNuCHI8rfg40mn4Xd1O5KbMTSpd7bgd85rLsCOAAbwS7zMPACh/K+9Yei7g0EB8TQuA3G1b8e+w8357FtiO/bOkyLbwf1Qly9U2dEKmLnRGpGtfN68s8IX98pI/bRhb5ELjmTc0ZMk6cBLsIedLAVm8G2fcy6OffxcvGuLzlr7EvdNlpP83NkH/rQuXg+57z2JaZnoX3fhvCMfNuDbHC5JxvYI1VfC3wY+BM2inc3sBt4KfAm7OZ1PxhRfhd207ijsVHmixzqvAS74d0q6k33HB4Fnan4zIWm9ftyHHYN8pOMnna5Hfj80GcxNQ7FpPoHg8B7Gm4/hW+b0nXfQny9U2dESmLmRGrGtXOXMsLXd8qIbvUlUudMFzJiGjz9IeyeXE8Dv8EumRlmkX0PUOhCHy+1d33pgsa+uLaRzzmyT33o1J7vQl77EsOzEM+3ITwj305xNrgOsu3Fbka3Ebsu9STgNGAH8CDwW+Aa4GdjtrENE/NC4D8T6vs68H5syv09jvu4HTvBDY8uDq7PrkOT+kMxmHZ5KKZ5FcOPgx/QtsYhcan/NcATmLeaENu3TZgW30JcvVNnRGpi5URqJrVzFzLC13fKiKXk3pfIJWdyzohp8vTK4v0A7J5sVdzIvkG2nPt4uXjXl5w19qVuG/mcI/vQh87F8znntS8xPQvt+zaEZ+TbHmSD6+WiA64FzgRejF2reiTwKuBs7KlM/xxT9tnAM8CPJ9RxOftOWnfW2Ldd2FT904Y+Pw24pcZ2mtYfiu9ho6TjXm8dUbZtjUPhUv8R2C8RV7H0SSNNiOHbpuTm2/WYxxY8ttG23qkzIgdi5ERqJrVzVzLC13fKiKXk3pfIJWdyzohp8vQ8k3WeLa2fcx8vF+/6krPGvtRpo1DnyGnuQ+fi+Zzz2pcUnoX2fBvCM/JtD7Khaibbl4vXX6m+lrkJM8Drim0+OWa9ddhJ6wzsBqKD0cMdxWsSlwIbgFuBm4GPAy/C/rO64Ft/SmJpfBg28jzgKOD4Ylsuj8N1rX8VNrX3UodttoWLpr56QL99W8ZF79QZAWHaPBWuOeF7jDFyoisZAf6+U0YYXelLhMiZVMTKCHm6Hl3xfh/Oj6n70a5tlPoc2ZUsUV5Ppi+eBTdNQ3hGvp2ObFgBPFpVuDyTbRFYU3pd4bgDLhyDCTXppnbnYk/p+TU2pXPw+lxpnTlsKuhRFeV/hE3X/xJ2A75VwNuBex3Lu9SfK7E0PrGoY1DPJcXfFzuWd9V4E3AQ8NCE42kTF0199YDJvp1Uvsu+LeOid+qMALc2zxXXnJh0jHP4azRuGy7t3JWMAH/f9fncVqYrfQmX8rkSKiNAng5JV7zfh/Nj6n60a76kPkd2JUuU18Yc8iy4aRriu4Tvdz/5NoxG47bhUn4nS8fP1gwWlGeyLWLT3tvghOJ9kpgzDttaiU3Nvn/E8nXFq0l5l/pzJZbGCw7bmBaNXTRdwE+PAeN8O6l8lzQdh4veqTMC3No8V1xzYoHxxxhCo2nICVc9wd93fT23lelKX8KlfK6EygiQp0PSFe8vOO5DjnSlHw3dyJeuZIlL+VyJpbFveeiOxq6a+npu0jZ8y+dMrO8i0H427GTE+NnM/Hzl5zlzG3ABsDlR+T4gjcMiPeMivdsnhEbSeSnybVykd/tI4zxRu7SPNA6L9GwfaRwW6dk+WX8X6eIgmxBCCCGEEEIIIYQQWVH36aJCCCGEEEIIIYQQQoghNMgmhBBCCCGEEEIIIYQnGmQTQgghhBBCCCGEEMKT/wPhz5BvLvkIXQAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$\\displaystyle \\left[ C {\\gamma}_{2,0,2} - L {\\gamma}_{2,1,2}, \\  C {\\gamma}_{1,0,2} + C {\\gamma}_{2,0,1} - L {\\gamma}_{1,1,2}, \\  C {\\gamma}_{0,0,2} + C {\\gamma}_{2,0,0} - L {\\gamma}_{1,0,2} + 2 L {\\gamma}_{2,0,1} - L {\\gamma}_{2,1,0}, \\  C {\\gamma}_{1,0,0} - L {\\gamma}_{1,1,0}, \\  C {\\gamma}_{0,0,0} - L {\\gamma}_{1,0,0}\\right]$"
+      ],
+      "text/plain": [
+       "[C⋅gamma[2, 0, 2] - L⋅gamma[2, 1, 2], C⋅gamma[1, 0, 2] + C⋅gamma[2, 0, 1] - L⋅\n",
+       "gamma[1, 1, 2], C⋅gamma[0, 0, 2] + C⋅gamma[2, 0, 0] - L⋅gamma[1, 0, 2] + 2⋅L⋅g\n",
+       "amma[2, 0, 1] - L⋅gamma[2, 1, 0], C⋅gamma[1, 0, 0] - L⋅gamma[1, 1, 0], C⋅gamma\n",
+       "[0, 0, 0] - L⋅gamma[1, 0, 0]]"
+      ]
+     },
+     "execution_count": 114,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pe4 = pe3.all_coeffs()\n",
+    "print(len(pe4))\n",
+    "pe4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 147,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABccAAAAmCAYAAAABSiOjAAAABHNCSVQICAgIfAhkiAAAGWRJREFUeJztnXm4HlV9xz+XNSFQNgVUREACBIUgCVRFeEIFZHEhiCJW6C0RraiIIGBA20CrWBAIqJHyIFyWUlCpKIgbuwaUFFD2JZQUkbBEaFAQQgL94zfTO3funJkzyzsz77zfz/PM877PnGXm/M7vbL85y9CcOXMQQgghhBBCCCGEEEIIIQaJlTz87ATMAybliHdqsdcRQgghhBCiU6wLPAm8uWPPEuP5PnBUg89X/refJB1pWm+EEEKIfmICsFkO/8cB09I8ZBnHPwucDpwGPO/50K8Byz39CiGEEEII0a9MBf4deAx4EXgEuAh4S8TP8cBPgYf76FmiGCcBXwLW7lH8NwEXprjH8//TwJ3Ac8F1C7Bvj95N+JGkI73WGyGEEKJLvAgcDbze0/91wBnAP7s8pBnHpwNzgP3w72AfBdwN3OPpXwghhBBCiH7kEOA24CXgQGDL4B7AEcHvGsBhwLl99KwmGcHGH/3KndhHi495+h/BP71DwPaYHiSRlP+PAV/EZktNxwaHVwDbeT6zjYzQPR3JqzdCCCHEoHMi8G1gFQ+/C4A9gPcAH0nykGYcPxb4DrDE88WmAnsDF3v6F0IIIYQQoh95J3AecAxwKDAfeBT4JXAwMDvwty/wCvCrhp71AHArsGYszmuBfyvxTm2grWn7EfDRHsQ7GVgLt3E8Kf9/CFwNPAQ8CJwA/Al4R8RPW+VYBW1NW5KO9EpvhBBCiC7yNPBjbPWVDy8BpwD/lOToMo6vBOwF3OH5kCHMYu+coi6EEEIIIURHmAvcjC3RTOKZ4PddmDHz1Yae9WFgW2BG5N5+2EziL5d4pzbQ1rT9BtgRmFhxvNMw4/dvHe5ZurYycBBmKL45cr+tcqyCtqYtSUd6pTdCCCFEVzkXa9e39vR/T+B3ctzBZRx/EzYz4S+eD9gXWB3bB08IIYQQQoiusjVmxPqWh99NgccbfNbvgNsZHTSsBnwdm9CyOnADcG/gb3+PZ+yDzcZ9CDi8Qr9FqDJted71jRlxPw6siv8+mL7sgM3+/rPDfVOSdW3bIMxLwDxsEHlXxD1Njk/RuzzPkmMVVKkjPwKexQ7PzCJLDkk60iu9EUIIIbrKK8A3sLMvfQht3G+NO7iM4xvkfKFjseWeQgghhBBCdJntg1/X9hZRJmCHBkWZg83uTbtmVPQsMIPqVsH/IxkdSCwHPgdsg+3DeCa2b7WLVQI/u2PbKX4GeF1Jv8djhtvw+tuEe7ukvFMVacuTLjziDgdeSTOAy6R3Gul64Mr/BzA9ejtwNnagZ3xQ6JJjL/I8xDeP2qAjYCs3DklxD/GRQ5KOpOmNEEIIIZK5BNiTsQfUZ7Fh/IbLOD4hR6RbYh2SH+QII4QQRbkQm8k0qekXEWIAUHkTaUzDDLmzCrr3K6HxyjWDN8oSYN3YvW8CUzKuWyt6FphxdCtsIHACcDSwDFiMzZgFK+fPAq9JiX8nbJbt74EXsL7/e0v6PRsz3IbXjxLu/VfKO1WRtjzpwiPu9YLfpxPClknv20g3jrvyfxmwMIh3NrYty5ExPy459iLPQ3zzqA06AnA9tl97Fj5ySNKRNL0RQgghRDJLgZ+Sb5XiuI/hLuP4UI5ID8JO2PZdMjoZOBnr3D0NvBz8XoMlJu2LfZfYEFgBnBW7fx02kEybASF6j/LBcOkpNFOWpwMfw5bNPN+D+KOorqoXybse8tRtdZY30Z/cBlwB/AvjD7zzcY8SbW/WBz6OGZUWYjMql2IHDc4i/UD5Otrvu4PfXR3u0frqDmxmapQlwP0Z1wsVPQtGZ85+BTO6X5ngZzq2pcPvHc8B2+4h6v4Y8IaSfp/B8ji8/pRwL22bxyrSliddPnFvi42LnkzwXzS9mwPrYFuEuHDlf5yVGD8RyiXHXuR5Eml51AYdyYOPHJJ0JE1vhBDtRWMYQ/Yt0SS/wM4ZWdXT/7ixxCoVvMQ+wK89/A0BJwLHYfu93Yzt2bYU2+N8T+DdmLF9EArOB7AMic64H8L2E3wF/8NQRfUoH0Zx6WlTZfmrwHPYAcC9QnVVvUje9ZG3bqujvIn+52TsILkjMJ3J6x4SbW8+hOndYmy25qPYoGt/7OCdvQM/8YMH62q/FwBXYzPA1wDmB+8yDfgE8CXglsDvz4B/xWakLmnoWQ9iWyYegs0+jrM+tkpkFukHhyZNnnH5z+O3DFWkrei7uuLeFZvBVCXTgt+XGbslygrgvuB/Uv5/DfgxZqxdC/gotmXPvrH4XXKsI8999a8oVem/Lz5ySNKRXuiNEKJ3aAwzFtm3RJPciPV/dsbOE8lNlnF8WYb7Glgn4wKPZ50HDGPLzD7K6DK2kInAUcAWHnF1gZnAHxl7iOlkYG2sk+uzfFb0BuXDKEl62lRZ3hLbv/Fc/A8LLoLqqnqRvP0ZBs4HdqNYo5+nbqurvPUbw5TLgy5yKzbT+ZOYYW5FTveQaHszBLwfM+q9EvFzfBDfBzFD+eWxOOpsv/fH9is+Cjsscxnw39g7RweAd2EfBz6CGbibeNZCTI7nAPfE4l4dG8iejA3s0/gDdohiyMbAogr8lqGKtBV5V1fcE7EDL/fMCJ+XHYLf+bH7d2MzjiE5/zcCLg5+l2KrfffGDOlRXHLsdZ7n0b+iVKX/vmTJIUlHeqU3QojeoTHMWGTfEk3yAHbuyq6kj9Fedjm4lqWG97O2Stkem7b+YIa/o7CK4z7sMJh4xQE2+P4Ko/vE7I+9+G+wL29JnIh9if9ExvPbxtrA32DL+qKDxHBWiM+hS2XpsnzL4psPXZdhkp4WKctVcShmMLms4nijqK6qF8m7XvK0Ma7yJvkXo+tyuxTYBPugUsQ93t5cF/x/JebvCWyvYRg9sDJKnf2ol4BTgO2wPfnXDZ7/j4w/FPFEbOb8yg09azWsb39hzO8QMILJ+6KE517L2O0gbsUOO3ojNuifiRno8/pNYxg7sNSXImkrk66suGdhK2p9VtWCf3pnB8+NX9vG/MXzfxirc1bHZk/vznjDOLjlWGWex/1n6Z+LYerXkTTyyiFJR/LqTRG63g4VRXJxI9m40RhmLLJvtZdBkcsKbDLOX2f4ewpL67hVXi7j+EZYYV6YEXH4FSzNiP46rFJYju0Bk3WQSThD7Uls35idgGMT/G0e3F+AzWzrJ/bFOmr/Gbs/PfhNO1SmKros37L45kPXZRjX06JluSp2xyq9Xg0cVFfVi+RdP3naGFd5k/yL0XW5hbNZ9yjo7uoXJRHO+Fie4FZnPyoPP8Nm8m7c0LOmYh8a7o753Rk4EJux+tvgCo2tQ1g//5mI/+XA5zFj4F3Y1jeP5/RbNXnTVjZdaXGDzer/bPlkFaaorrnkWFWeJ/lPk2OVVKEjYPsHfw/bUvQx4B0Ov1m6n6QjdehN19uhokgubiSbZDSGGY/sW+1lkOTyGNkrNV7GZplvEHdwbauyF9b4Zy192Cz4fSLFz5HYoS/nM75TksZ8RpdmTE9wPwsrgIczfmZR25mJHW72i9j9OiuPLsu3LL750HUZxvW0aFmugknYSpX76N3BgKqr6kXyrh/fui2tvEn+xei63BYEv65DI7PcXf2iOKtg+wZD8t68bTWOQ/LB1nU9ayq2yvOF2P1f4Z4oszW2bU38Q/eVjD/QMI/fqsmbtimUT1ea3M7JeN86KKJrLjlCNXme5D9NjlVSlY4krXzJo08hSTpSh950vR0qiuTiRrJJRmOY8ci+1V4GSS6Lse3Jhkg/Q2QEOwtgDEkdgunAu4BjPB6+TvCb1JEK2S/4zbNcLuQlbA+nKbH778e+Tp1DOwdAaUzAPj78hLFLYVfC9m9fgc1cqIMuyrcsefOhqzJM0tMyZbksb8CWCC/u4TNUV9WL5F0veeq2rPIm+Rejy3JbirUVmxRwd/WLkvgadhjh1YzfGqKJflS/8E3G610W92HLxqv2WzV509Yv6aqbXsqxiP8qkY6M0uV2qAySixvJZjwaw4xF9q32Myhy+RNm6J+Y4e9MbAb5gdGbceP4LOCL2H5BT3k8fFLw+5LDfU3sUK9XsT1uinA/drp6uDxwIjAXO4X9+ODertjX+ceDZx1Q8FmHA49ghfo28p0qPBubGfUc8HTwPm9N8LcnJpcfxO5viaXzfno3MzYJH/mCf/rSqEO+ZSmSD74yrEJPy8gwT/i4nlZRlsuwfvD7bIqfRdj7+V4XR8LWVVc1XY7KxLGI4vKNM0jyLvoOixgv0/MDt+sT3EYy4stTt/mUN996D+qrt5IoowOLqDYPoL42t4n25hnslPi87q5+UZwjgKMxGR6c4N5UP0oIIfqJfhm31DX2CxmEfk1R6upzQ7Oy9aGuMQw0XwZ9ww+qfasN+ZOHruldEuHHmUmpvszf3sD7MPv3yjDeOP4cZmmf4PnwcLq6a8r6ayPxps0uT+P+4Heb4Hc2tp3LcYwO3CdhhyB8puAzwL4anAl8FfvCNR/7+uWaBRVnBjAPeCf2cWE5tjfdejF/M7F95eKHEjW1FNhHvuCfPhd1ybcsRfLBV4Zl9bSsDPOEj+tpFWW5DOFy1bS66WFs/yjfK7r/Y1111QyaLUdl4igj3ziDJO+i7zAXOxwlev0wcLsgwe2KjPjy1G0+5c233quz3kpiBsV1oOo8gPra3Cbam4mknzXhcnf1i6J8Onife4HdGL8XMLR7SxUhhGgL/TJumUE9Y7+QQejXFKWOPjc0L1sf6hrDQPNl0Df8oNq3ms6fvHRN75IIt4UZd9hmAsuwmeZrhDeG5syZE/e0DbZcdWfgDxkRnonN5JlA8uzxDbAN4JcFD12R4CeL/bG93D6PfcG4B7gDU+Iko/yrwIeA7+d8zm+AO4HDIvceCuKZnTMusK9nS7FlN+Gecytj8liAfamIMhf4HCbPbxR4XlHyyjckKX1p1CHfKiiSD0VkWERPy8rQN3ySnlZRlsvweqw+mo9t+1Q1TdRV0Ew5qrosFmGQ5F32HaIMYzOXdwNuyBk2T93mU9585V9XveVL2bZjmOJ5APW1uVHqaG9WwgYVjwBvzuGe1i8KORI4A9vX8924VzY21Y8SQoh+ol/GLXF6NfYLGdR+jQ919LmhfbJNoqkxTFttB4Ns34rShjoyiy7pnYuvY6tM1yR9tcKq2KHZ5xFZ+Zu05/i92Eb6p2U8GOyLGbinrT+FLUteDfsyk4brQJboF44zscOYDiddsfOyGjAN+Hns/s8xZSnCWliaorObdsWWqyctHZ4W/Db5ZS2PfJPS56Iu+VZBkXzoBx3NEz5JT6soy2VYjC132qoHcUNzdVXd5agXZbEIgyLvsu9QJXnqNp/y5iP/OustX5qSf0gdbW5Zish9K2yWhmtPSZd7Wr8IbDbLGUG43Ujf8q/OflSeLaZ06dKlq8xVNf0wbkmi1+2g+jVuet3nhnbKNolBsW/5hh9U+1ZZmhiTd0nvXEzAPlhlrer4DLZCYCR601Vgr8G+mPxVRqT/E/xumOJnbvA7DzupPM4Q9pXpUkf4hVgCP4RtFv9t7AtHlbyG0a9eUZ4ENioY51xsMPfryL39san+P4z5LXJYwQimyMMF3y+kqHyT0ueiLvlCObkUPTSiH3Q0T3iXnpYpyyOU09dXgZuwdGxRMI4smqir6i5HvSiLRRkEeZd9h6rIW7f5lDcf+ddZb/nShPyj1NHmlqWI3N8e/F6f093V3gB8GTuA8zZsxvgS9yvX3o8a0qWromsT4EbsYMc7gQ+24J10tesKGaHZsV8e6m6/Rygvmy72a0ZoTmfy9lvqlO0I5eQyCPYt3/CDat8qS536GtIlvXOxIfAo2Qb/vwd+Fr+5isPzU8Dq2KD49pRIHw5+N8Y6dUmcBWwHHArchVn9H8ROB30jtmR7Y+ASR/hl2DLcLYL3+nLK+5QlLsShhHs+nIp9RduFsUtt9gNuZnxmT8Fm3z+Pe8nJEmyz+JDww8byAu8XpYh8XenLotfyhXJyKZIP0F866hPepadlynIV+no5Nmh8D1a5V03ddVWT5aiqsliGQZJ32XcoS5G6Lau85ZF/HfWWD03JP0qdbW5Z8sh9T+zdkozcae6u9ubvgJOCML/EluTGWcTojI8m+1FClGE5tuz8d9hy/duAn9LM+S6i3TQ59itKXe13FbLpYr+mKZ0p02+pQ7Zl5TJI9q2s8INu3ypLHfoa0iW9c/F6Rm3ULlYB3gJclOSQ9jKvy4j4duxL0RRsKxZXXLOwgfZhwE7AHsCfsaXbt2Cb91+V8pz7sUw8DvjfjHcqwhKsEMS/RoR7SuXhNOBj2PLfqEFhR6ySPCMhTLjkZBImqyTiXza2xTaQTzvAypc88nWlL4065BtSRi5F8iGk7TrqGz5NT8uU5Sr09fLgXQ8BvlUiHhd11lVNlaMqy2JZBkHeZd+hKorUbT7lLUv+ddVbPjQp/zi9bnPLklfua2ODo6uA3+dwT2tvNgt+V8b2HE/iRkaN4033o4QoyuLgAhusPovNnHq0sTcSbaWpsV8R6m6/q5JN1/o1TehM0X5LnbItK5dBsG/5hB9k+1ZZ6tTXKF3QuzTeDFyQ4WcD7IPDOGN71t7Aq2a4L8UOSNouwx/YIZ8zgTdge8msh1nsP4wl4I8pYdfFjPDf83hOEZZhMzX2iN3fA/sS5stZjBase2NuM4PfpP2YLiR7Sd1eEf/rYDI/m7EnyxbFV75p6UujDvlCebnkzYcobddR3/BpehqStyxXpa/LsP2xdsKWafWKXtdVTZajqspilXRZ3mXfIc4IVg/dkDNckbrNp7xlyb+ueiuLquQPxfMgSq/b3LLklfsh2B5/rrNqXO5p7c0csnV2RsR/0/0oMZjMxg4hew47p+FK4K0J/m7CdDSL6djYK+kjkxhsmhr7FaXO9rtK2XSpX9OEzpTpt9Ql2yrl0mX7lk/4QbZvlaUJfYVu6J2LDYPrlxn+VnM5uGaO5+HHwAEVxONiCJgKPID7xNE1Gbsv6qbA9thm+r4zL07HptbfCswHPolNyz/bM/w8rGDtFzw3/Nrx5+CaiS2ZfMQzvjR2wZbtnF5BXD7yhez0ZdFr+UK1csmDrwzL6mlZGfqEr1JPQ6rMlzOAf8CW27+vgviqxEcPmi5HVcXRBvpF3mXfoUnSyptvvVdHvZVG2+RfV5tbV3szETMQXk5yZzTNvRftjS9N9RdEt5iBldUFWNk+CTu3aRtGD/Qawsre5RlxrY8ZE2ZR/zZnov00MfZretzi2w5WJZuu9Wvq1pkq+lt1yLYN7X+/lMGs8INu36ojfwax7i8afkfgRWxCQiFcM8fzdMouASYDbyr6EhlMxjIobbP46YF76OfU4P9JET/DWLo2dcRxGbZ090vYRvy7APsweuhoVvhPYSfcXsvoEsnFwBcC9ymYUlXBldgsrCcqiMtHvpCdvmHKyTcrjqznQ7VyyYOvDMvqaVkZ+oSvUk9DqsyXF4GDsVOvJ1UQX5X46IGPHg/TOx3wjaMf6Bd5+7xDW0krb771Xh31Vlr4tsm/qjYX0tNdR3tDEPYc3PJMc+9Fe+NLU/0F0S3eA5yPraK9C6svXwvsHPEzGSvLt6XEszo28+5kmlvFJdpNE2O/psctvu13VbLpWr+mbp0p22+B8vYYH9m2of2vqgwO01v7S1b4rtu3oPm+9iDW/UVtFXsBP8FW8/kwzubtmjn+F88IwTqE84EDgVNyhPMlXM6dlok3MPY07yQ2w5ZKPJbiZ15wFQmf9fy24iNf6L18s+Jos3x9ZXgD5eVYRoY+4fuBmyjxRbCH+OiBjx73Wgd84ugH+kXeba67fHCVN996D3pfb/VT21FVmwvp6b7BI44q2ov7sC1QiroL0SXWwiYePRO5Nw1bwvxbR5ghbLum60g4HEqIHtAv45a622/1a9zU1eeGcvaYrPBtoaoy2Gv7i0/4NtK1vnZV9Evd7xM+zhDwXuCIHGFeGBfJnDlzkjxuglnmZwJXeES8D2YYT9pnry0sAI4Frm8ofNepQj6SsfRUSAfqRvJuHuVBMSQ3IdrFZcCW2KyrFcG9U7EB2xRHmHdhHyDvjNw7GJuJLkTbUTuUjOSSjORSLbK/9B7pbDJtk8u7gW9i29pl7YKyKbYV0AHEtrxzGceHsFkPhwP/4flC12MdwKs9/QshhBBCCCFEv3MqtnfpLsDCyP3rgMcDNyGEEEIIUS0/AL6Ln+16G+AeYGts//X/J23P8avINxP808AJKXEKIYQQQgghRJc4DTgEm7m0MOb2NtL3GxdCCCGEEMWYCqyN/6TuHYCHiRnGId2QfTLW0dsoxU+Ue7HDOT/u6V8IIYQQQggh+pWzsFnhu2FjoSibA+sAt9f9UkIIIYQQHWcIOyj0UE//K2PbuZyc5JhmHL8X+DxwDfABz4d9C9tTb0tP/0IIIYQQQgjRb8wDhoGDsO0oNwquNQP3acHvy9hq3PBy7T8uhBBCCCH8OAaYCyzy8Psa4ALgVuA7SR6ytkD5PrA3sC0w0fMFj8Z/trkQQgghhBBC9BufAtYCrgUWR64vBO47BL/zsQM2w+u79b6mEEIIIUSnmAjcgv+hnkcDl5Ky04nrQE4hhBBCCCGEEEIIIYQQorPo8EwhhBBCCCGEEEIIIYQQA4eM40IIIYQQQgghhBBCCCEGDhnHhRBCCCGEEEIIIYQQQgwcMo4LIYQQQgghhBBCCCGEGDj+D1NgCm27mjEUAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$\\displaystyle \\left\\{\\left( \\frac{C {\\gamma}_{1,0,2}}{L}, \\  {\\gamma}_{2,0,2}, \\  \\frac{L {\\gamma}_{1,0,0}}{C}, \\  \\frac{- C {\\gamma}_{2,0,0} - C {\\gamma}_{2,0,2} + L \\left({\\gamma}_{0,0,2} + {\\gamma}_{2,1,0}\\right)}{2 L}, \\  \\frac{C \\left(- C \\left({\\gamma}_{2,0,0} + {\\gamma}_{2,0,2}\\right) + L \\left(3 {\\gamma}_{0,0,2} + {\\gamma}_{2,1,0}\\right)\\right)}{2 L^{2}}, \\  {\\gamma}_{1,0,2}, \\  {\\gamma}_{0,0,2}, \\  {\\gamma}_{2,0,0}, \\  \\frac{C {\\gamma}_{1,0,0}}{L}, \\  {\\gamma}_{2,1,0}, \\  {\\gamma}_{1,0,0}\\right)\\right\\}$"
+      ],
+      "text/plain": [
+       "⎧⎛C⋅gamma[1, 0, 2]                  L⋅gamma[1, 0, 0]  -C⋅gamma[2, 0, 0] - C⋅ga\n",
+       "⎪⎜────────────────, gamma[2, 0, 2], ────────────────, ────────────────────────\n",
+       "⎨⎜       L                                 C                                  \n",
+       "⎪⎝                                                                            \n",
+       "⎩                                                                             \n",
+       "\n",
+       "mma[2, 0, 2] + L⋅(gamma[0, 0, 2] + gamma[2, 1, 0])  C⋅(-C⋅(gamma[2, 0, 0] + ga\n",
+       "──────────────────────────────────────────────────, ──────────────────────────\n",
+       "           2⋅L                                                                \n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "\n",
+       "mma[2, 0, 2]) + L⋅(3⋅gamma[0, 0, 2] + gamma[2, 1, 0]))                        \n",
+       "──────────────────────────────────────────────────────, gamma[1, 0, 2], gamma[\n",
+       "               2                                                              \n",
+       "            2⋅L                                                               \n",
+       "                                                                              \n",
+       "\n",
+       "                          C⋅gamma[1, 0, 0]                                ⎞⎫\n",
+       "0, 0, 2], gamma[2, 0, 0], ────────────────, gamma[2, 1, 0], gamma[1, 0, 0]⎟⎪\n",
+       "                                 L                                        ⎟⎬\n",
+       "                                                                          ⎠⎪\n",
+       "                                                                           ⎭"
+      ]
+     },
+     "execution_count": 147,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Solve can be very slow as the expansion size increases\n",
+    "#en_soln = solve(pe4)\n",
+    "# Using linsolve is faster\n",
+    "soln_var = {a for a in ftmp_en3.free_symbols if type(a) is Indexed}\n",
+    "en_soln = linsolve(pe4, soln_var)\n",
+    "\n",
+    "en_soln"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 148,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAACJ8AAAAmCAYAAABgHagYAAAABHNCSVQICAgIfAhkiAAAG4BJREFUeJzt3Xn4HVV9x/H3L0RIIIgIKqAiKrtE0EQeN3iiAi64AK5Yib9K1YobaiuC2v6g1VgRQayR+rhc0bZaoaIsBWWJaFCICLKDWKgikcWgIFvY+sd3rrl3fufMPbNvn9fz3Ocms9/vfGfmnPmdOTM1MzODiIiIiIiIiIiIiIiIiIiIiEgWcwKm2R1YDmxU8raIiIiIiIg02abALcDTO7YucTsJ+GBN69b+bz5fftSZNyIiIiIiIiIiZTgMWDRpokmNT94LfBY4Bri7gI0SERERERFpol2BfwduAu4DbgC+ATxjZJojgDOBX7doXZLdUcDHgE1KWPb5wIkJ4137/93AZcCd0eenwL4lbJuE8eVHmXkjIiIiIiIiIlKHc4FjgX9Kmiip8cliYAbYD93wFBERERGR7loKXAzcD7wR2D4aBvC+6HtD4O3Al1u0rroNsDplW12GNQx6S+D0A8J+7xSwG5YHLr79fxPwEewpk8VYpf8U4JmB29dEA9qbI778SJs3IiIiIiIiIiJNtwrYG3gp8CbfREmNTz4MfAW4vdjtEhERERERaYznA18F/h54G7AS+A3wY+Ag4PBoun2Bh4Gf1Liua4GLgAWx4ecA/5Zju+rW5N/1feDNBS9zO2Bj/I1PfPv/e8AZwK+A64CPAncBz4vGNzmOeTX1t/nyo4y8ERERERERERGp0/3Ap4F/9E3ga3wyB3gZcEkJGyUiIiIiItIUxwEXYN1GuqyJvl+INRZ4pMZ1vQFYCCwZGbYf1hPGx3NsV92a/LsuBJ4DzC9wmYuwxiWXesaH5Np6wIFYY4wLomFNjmNeTf1tvvwoI29EREREREREROp2JbAj9nDVLL7GJ0/BnsS6t6SNEhERERERqduO2B+IvxAw7TbAzTWv65fAL6JlAawPfAZ71+oGwArgqmi6Ayas4xVYbxK/Ag4pcNosivxdEL69Tw5Y9s3Ao4CtAtYb6tlYzyV/9ozfBn+uLYzmux9YjjXAuDwalxTHW6NhZez3kDjmVXSOfB+4AzgpYNqkOPjyo4y8ERERERERERGp27D9yC6ukb7GJ48vZ1tEREREREQaY7fo2/f6k1HzgPscw2ewHiqSPksKWhdYo4Udon8fivWg8XngQeD9wM7Y+1c/B2zoWcbcaPxewK7Ae4AtC5j2CKxhxPDzV45he5T4u9Jub8iyhxVqVw8WWX/vIpLzIGn/X4vl0nOBE4ATGa/s++II5e33NPuoCTkC1vvQ0gnTwOQ4+PIjKW9ERERERERERNruCa6BvsYn80rcEBERERERkSYY/mHY1wPFqNuBTR3D/xXYacLnooLWBdb4YAesgvdR4EPAWmA11usDWC8XdwCbe5axO9ZLxG+Be4DvAq8sYNoTsIYRw8/3HcN+XuLvSru9Ict+bPR9m2P+rL/3WSQ3Pkna/2uB66PlHo69uufQkfG+OEJ5+z3NPmpCjgCcB9w1YRqYHAdffiTljYjU70TsfLFR3Rsi0gM63iTJIqyx/sEZx4uIiEh9nA/++BqfTJW4IV13LlYg8j2t1QdPAB4CjveM3w5Yht1wvQ14IPo+G+vGeNJTaiIiItJOKgOs4ysvqSxZrSui7z0940dz8hKsZ4W424FrJnzuKWhdsK73h09gjVpOdUyzGHvlx289y9gqNu4m4IkFTLsGaxgx/NzlGOZ7tWsRvyvt9oYseyH2CpVbHPNk+b1PAx6DvULGJ2n/x81h/OGRpDiWtd9HTdpHTciRNCbFwZcfSXkjIvVaDLwF+BRwd4nrUbm3Wop3NdLWVao63qS9LgZOAf4ZWJBh/FC8fr0Z8DdYw+Fh+fJPwE+whiy+v4uB6uQiIl2jcuI6rvvRea57zuvp3AwLEr8p7P3dD2M3DPvqNVjCfTc2fAo4EjgMe0f3Bdg7tv8EPAXYB3gJcCAq3ImIiHSJygCzucpLKktWbxVwBtZ7yYbASqzCtQh4B/Ax4KfRtGcB/4L1qHB7jeu6DntN6lKsB424zbAnTA+Olu/ietigiGnzKOJ3QbbtTVr2nsCZE+ZPY1H0/QDjr8t5CLg6+rdv/38KOB1rDLEx8GbslU77jkyTFMey93voPsqqqBxJY1IcfPlRdN6ISHE+CdwJfLGk5avcWy3FuzpZ6iplH2/SDcuAC4H3YTmTdjzMrl+/Hsu71ViPd7/B/uB2APBl4OXRNPEyo+rkIiLdoXLibPHrZSnXvUmNT9ZOGC/jtgM2wW4ahnSn3VX7A38Azo8N/yowjXVb/GbWdY08NB/4ILBtydsnIiIi1VIZYDZXeUllyXocALwfy8EvYHWg/8X+yD9a8bocu+n5JqwBSV3ruh6rFH4JuDI2bgOsArkMq1T7/A548sj/nwTcWMC0eRTxuyD99iYtez6wH3ZDoijPjr5XxoZfgfWWAf79vwXwzej7T8Bl2I3zs0amSYpjmfs9zT7KqqgcSSMpDr78KCNvRKQY2wN7YX949PWylJfKvdVSvNOZBr4GvAhYkXLetHWVKo63Npom+z7oqouw3iLfiTXAfijleJhdv74OeDVWz3p4ZLojouW9FqubnRxbjurkIiLdoXLibPHrZdbr3gNJI33diw2H35ww7wHRwi/EWgi5HIm1Hn1H0kZ0yPAptqT3d0O3Y7cJ8GKsC+TRguAHsYP8auC5zD7IwSoin8C6OSpKl2OdheLhpriMUzzcFJdxioeb4jJbljJA1+PoKy+FliXz6np807of+DTwTOxd9Jti++IfgPti0x6JPXG3Xo3rWh+rr50YGz4FDLDuMr8RG3cO468KuQh4BvZH9flY5fP0DNNOMg3MBE6b5Xel3d74tJOWfTDws+gTYprJv/fwaL3xz8LYdK79P40dsxtgPYDsxXjDE/DHEYrb72njmGSa6nMkSZo4+PIjbd5kofP4OMXDTXGZ7W3YOePbJS1f5d5qKd7VSltX8R1v2gfZdD1u3wK2xsq3ace76tfnRv9/ODbt74ETon8vcSyrqjo5dH+fpqV4uCku4xQPN8VlNpUTZ3NdL7Ne927F4uDqLdbb+GQLLOjXJyz4FuCHwO7Ahx3jnxYNX4W1cG6rARbA6YBpF0ffP58wXZdjty92U/C/R4ZtiR3ADwJvwN7rnaTI1vBdjvWoAWF52pd4pNWXuAxQnuTRl7gMUJ7k0ae4DJicK1nLAF2Po6u8BOFlyby6Ht9RA8LL8iHOwnqieFJBy8uyrl2xm6hXxIa/AHgj1uPCpdFnIVYR3BZYMzLtg8AHsD+0X451SX1zymmLlvZ3kXJ7XdMmLRusZ5r35vtZmWXNNV8coZj9niWORSkqR8De7fwd4BXATcDzPNMm5b8vP6rIm76cxweoXJpHX+IyIPxavxd2o7WMxmEq91ZL8a5e2rqK73jTPsim63Eb9gq4d4bxvvq1z/Bp7Qcd46qqk0P39+nQAJXn8uhLXAYoT/LoU1wG6H50Vq7rZdbr3gPAtdiDUbP4XrvzMuxGTFIXKytZ1z3LYsf447EfcQizW5h2VehO6nLs9gfuxg7QoUOBeViXgq6boGXqcqyzUDzcFJdxioeb4jJO8XBTXMZlLQN0PY6u8hJUd6Or6/Et2/E1r2tXrBvpe2LDf4L74YKdsO6k4w28T40+o3ZMMW3R0v4uSLe9rmmTlg32epc6Zck1XxyH8u73LHEsSpE54npqNs2xAv78qCJvdB4fp3i4KS7jNgJ2w55+vLuE5avcWy3Fu3pp6ipJx5v2QTZdj9uq6HvPDON99WuXucDS6N9nOsZX2fik6/s0LcXDTXEZp3i4KS7jVE50c10v81z3BsCBrhFTMzMz8WGLgf/CuqG5NWDhF2E3dB49MuzVwPewLszelWpTm2dLrCua1dh7tX3mAH8ENoymD6nIdi1284DbsILb60eGX4u95/PFwHk1bBd0L9ZxoXk61PV4ZNX1uChPitH1uChPitGHuITkSt4yQBfj6CsvZSlL5tXF+MalPaeJiLRJ18/jKpcWo+txCc2T7bGy6Q+BfUrYDpV7q6V4ZzON/SHmRcCKFPOlrauEHG/aB+n2wVCX43Yvdh7fIsV4X/3a5zPAh4AzsCfAR9VRJ4du71NQea4oXY+L8qQYfYiL7kdn47pe5r3uzQN+jF1bx16zGH866GDgI9gOCWl4AnANsDHrugOeDxwH3A4cEZv2EOAG7H3mFwN7BK6jzvlXY79x0glveywO1xC+g0Jjtyf2pNXNWHdCrwtc/qgqYrcPsAD47siwBVhsHsHek1WXtuTp4VhL7juxE8GpwC4B84Xm6VDX45FV147JuLLypK3xyKotcWna+aSt8ciqqrjUGddJuVJEGaAt+ZVmfld5CbKVJfNqS57mOX7TntNERNok5DxeVBmoK/WXNscjq9DrfRGxyfO7spYXQvNks+j7joRpbozWHfr5ZjRfleXeuvdTnvlvJFt84/oU7zzrv5HZMf1aNO48x7hBwrLS1lVCjrc+3Ju8keL2wVBVuVtHHXsNsHnK8b76tcv7sIYn1wAHOcbXUSeH7p+PyrrP2NZ4ZNXlYx+amydNuN+YRlviUuZ9vj7dj04TR9f1Mu917z7g5cCrsLYl6w1HxBuf3Il1GTMvxcKvib53jr4PB54KHMZ4AfONwOeATwLPwrqv+R9g68D11D3/JFm6pgmN3UbAL4H3ZNy2qmK3P/Z+69NHhj0u+r4Tf9fPVWhLni4BlgPPxxqBPYi9j/yxgfOHUjzcunZM5qV4uLUlLkto1vmkL/EYqioudcc1SRFlgLbkV5r5XeUlqLZ736G25OkSqj1+RUTaIuQ8voT859C2lNcVD7fQ6/0S8sUm7+/KW16YZPhKraR7nr/GnpQM/dwczVdluXcJ9e6nPPNnjW9cn+KdZ/3HAUfGPt+Lxn3dMe6UhGWlrauEHG99uDdZ5D4Yqip366hjz2f26w8njffVr+PeHW3PVVivM2sc09RRJ4d+nI/SUDzcunzsZ6F4uLUlLnnXn6RP96OXEB5H1/WyiOveWuAurPeUv3C9dmdnrNuxFwC/C1jwAdh7kT+Ataq5ErgE+7GPjEx3IXAZ8PaRYb8CTsJ23CR1zz/JccD7sRa0nw+cJzR2ox7BusQ5KcW2VRG79YBbsFZWLx+Z7vHR8LVY8j2UYruL1JY8jVuAteDbD/d7xrNSPNy6dEwWQfFwa0tc4uo+n4zqcjyGqopL3vnLPH6KKAO0Jb9C5/eVlyBbWTKvtuRpXNnHr4hIW2Q5j2c5h7alvK54uGWJC6SPTZG/q4jyQtxW2H3OlcALC1wu1Ffuher3U9X569KneOddf9w02V75krauEnK89fXe5DT5XrtTVe6OqqKOPQf7o9kNwNMDxyfVr0cdChwLXAG8BH+P/3XUyaG/5yMfxcOtq8d+VoqHW1viUuT64/p0PzrOF0ff9TLvde9RwDnAV4n13hbv+QSs9ecPgWMCFz7aAuhzwFysm5jRHbA+sAj4QWzeH2A7a5K65w+xKPrO2vOJL3Z5VRW7PbEuFeNd3N2KdTG4PtYKK4krH4vShjx12RiLi6s1dh6Kh1uXjskiKB5ubYiLS53nk7zaFI+hKuKSV9nHTxFlgDbkV5r5feUlyFaWzKsNeepS5PGbput3ffTRR588nzJkOY+nPYe2qbyueLhlvd6niU0dvyut1Vh31DuUsOw6y71V7qem7Oe+xDvv+ouUtq4Scrzp3mQ2VeRuXlnivgMwBVyaYnxS/XroMKzhyaVYgx9fwxOop04OOh/FKR5uXT32s1I83NoQl7LX35f70S6+OPqul3mve+/BelkZxEf4Ans21jLm0QELvx5rOfR6YF/gi1gLoFGbs65lzahbgC0C1lHn/FsCOwKbJEwzB+sS5yH8BSSXkNjlVVXsDgAeZl3XgaOOi76XY7GMm8JaW33LMW6AHdDTAduapA156nIcllM/mzBdSJ6O6lo8BlSXJ3k1/Xw2qmvxGNCfPHGp83ySV9XxGJA/V6qIS1554xqSK3nKANCO/Eozv6+8lKUsOaAfeeoSej6DyXk6pY8+BX22Bn4EXI09ufLaBmyTPs36jBpQX7k0zTkUul9/aXI8BtRbf0kTmzLK66FC8+QR4HxsW7ctYTvqKvdWuZ/q3M9xfYh33vUXJUtdJeR469q9yapUkbt5ZYn7c6Pv81KMT/p7BMDHgU8BF2M9ntzu3+Ta6uTQ/fNRVfcZmxqPAe3Jk7yaXu6H5sZjQH/yJO/6dT/azxdH1/Uya7uGUX8NnOUaMdczw63ABljh8BcTFr4W6+5s22i+jydMG28VNOUYlqSO+ZcBb8WCOPBMsxP2bqe78XdNczvwkdiwNLHLq+zY7QdcwOwDBeB44JnA24DLsZZb1wEPAE/Gul98EvAfjnmHDaQeTLGtLm3K06GjsRZpezC5a6iQPB3VtXjUkSd5NfV8Nqpr8ehjngw15XySV1XxKCJXqoxLXlnjGpIrecoA0K78CpnfV17KUpbsW54OpTmfQfpzmkhWD2Ldlf4S6+b1YuBMsr9jWLqtrnJp2nPoqC7WX5oejzrrL1ljU1R5PY00eXIy1jjwpdhN5SLVUe6taz/VsZ/j+hTvvOvPK+t970nHW9fuTValytzNK03c98G2zdeQxDU+6e8RbwWOiub5MfZKgbgbWXfdqKtODt0/H1Vxn7HJ8WhjnuTVxHI/NDsefcyTrOvX/Wi3pDi6rpdZy3dDc4FnAN/wjXQZ/rAtPePjrsF2wmHAHz0b+BCzW+sM3700Sd3zTzLsmmYj4GDPNM7WP0yOXV5VxO452IF6rGcZj2BxORl7d9XuwN7An7FuGH8KnA6c5ph3IXBXND6vpufpqGOAt2DdARZ9Q2SoS/GoMk/yalJcQ3QpHn3Kk1FNOJ/kVXU8isqVsuOSVxXnkzxlgKGm51fo/EnlpSxlyb7k6agqzmciWa2OPmA3J+7AnmT5TW1bJE1WR7k06zm0q/WXNsSjrvpLlthUvZ+zOhnbnqXAFwpedtXl3jr2U5P2cx/inXf9Rcl63zvkeOvSvckqlZ27eaWN+ybYH8ZOA34bOH7S3yOeGn2vBxzqmeZHrPvDZZ11ctD5KK5L8WhTnuTV1HI/ND8efcqTKtbfh/vRo5Li6Lte5mnXALadc/A0lPG9dmfoURPGD22KddnyHc/4tdiTX3vHhu+NtbaZpM75p7GWRoOEaU5kche7L/PMOyl2eVURu/2j76T3KwKcEU37ROx9Vo/FWka9Afg68IfY9I/BWqedgN28zavpeTp0POtOFFcFzjPN5DyN60o8qs6TvJp+PovrSjz6lidDTTmf5FVlPIrMlbLjklfeuE4TnitpywCjmp5fofMnlZfSliX7lKdDWc5nkO2cJv1zOLAKuBO4DTgV2MUx3fnY8TrJYqwu7bp5LlJHuTTrORS6WX9pQzzqqr9kjU1R5fUspgnPk7XYe9t3x7qZLkMV5d669lOd+9mny/HOu36XAXa8rEgxT9b73iHHW1fuTaYxIP0+iCs7d/NKG/elwDzsj2curvGT/h4xw+S8XTIyfZ11cuj2+Wia8u4zNj0ebcuTvJpY7ofmx6NveZJ3/dPofvSoSXH0XS/ztGsAi6eXr+eTNKaAXYFrse5ZfD6Ldb9yEbASeCewFXZAhah7/jKExm4B4+/H3AbYDVhD2JN0Zcduf6x76RsClxdqD6wbpM8WsKy25Oly7ESxH7Z/h63e/hx9itKleNSRJ00/JovSpXj0MU+adj5pSzyKypWq4lJ3XMvWlvwKmb/I8lLf8rSq85n01xIsz1Zhx8VRwNnAzljOEQ3fDXtyJslmWCX+YKp/BYG0Q9Xl0iLOoV2qv7QlHnXUX/LGJm9c8pYXQh0L/C12rn9VgcvNqy37qen1h1BtiXfby8FJx1uX7k1WqarcraqOPR9rCH4y9nqcON/4sv4eEaqP1+mm3WdsQzzamCd1318L1aV49DFPmnZtjWvL/eiQONZyvfT1fJLmJtl2WIAvmTDdt7Euzj4GXIodUK8A/i8aPx2td5uM809aRsj8VQuN3eJomuF0R0f/Pmpkmmny/fY88++EHVBFOxVr1fz7ApbVljx9F7AxcA7ruu5eDfzdhO1Oq0vxqCNPmn5MFqVL8ehjnjTtfNKWeBSVK1XFpYq41qkt+RUyf5Hlpb7laVXnM+mvlwJfA67A3gd8EPA44AUj02yH5eHFCcvZAHuaZBn1PQEuzVd1uTTkHDpNvnpd3vmL0qV41FF/yRubvOWpkPJCEe7DzvM/x7qZboq27Kem1x9CtSXebS8HJx1vRd2bhH7tg6pyt6p7DdsAX8IfT9/4sv4eEaqJ1+lp6r9PX4QuxaOJeQLNOPbz6lI8+pgnTbu2xrXlfnRIHMu+Xjrbk/h6Prk3xYKH3eZN2glgrXCWe8Y9FesS5qaM84csY9L8VQuN3QqspVWSvL+9bbFLqy15Omk/F0XxcNMxOU7xcGtLXJp2PllBP+IxVFVc8s4Pzb7GtyW/QuZvorbkadXHr8jG2IMaa0aGLcK6XL3UM88U1u3rudiTKyJVCDmPh5xD89briqgXFkHxcAu93hcRmzzlqRWB21CE86NPk7RlP4XM3wZtiXcXysG+462oe5PQr31QVe6uCFhGEeeKq7FX5GQd3wVF7dOu3KdXPNy6duznpXi4tSUuTbu2xrXlfnQT4niPa+DUzMyMa/jWWMua/YFTytumMauADwPn1byMtsr72/scuzSUp+MUDz8dk+MUDzfFZZzi4aa4FENxLJfiK13ybWB77CmWh6JhRwOvxJ4acXkh9oeVy0aGHYT1pCLSdDqHj1M8/BSbdtB+qpbiXT/tg2wUt27Rffpxioefjv1xioeb4lKMrsZxG+xVPq/D8XpqX+OTKewpr0OA/yxv20REREREREQa42jsnbl7ANePDD8XuDkaJyIiIiIiIiIi0kc7A1cCOwLXxkfO8cz0CHAasEt52yUiIiIiIiLSGMcAS4GXMN7wBKzb1Ysr3yIREREREREREZHmeDbwaxwNT8Df+ARgGXbjbYsSNkpERERERESkKY7HejV5EfY+3VFPAx4D/KLqjRIREREREREREWmI9bBXAS3zTZDU+OQq4APA2cBrit0uERERERERkUZYDkwDB2Kvn90i+iyIxi+Kvh/AegcdfnaqdCtFRERERERERETqsTnwdeAi4Cu+ieZOWMhJwIXAW4EfAPcWtXUiIiIiIiIiDfCu6Puc2PAjgRmsO1GAlbHxVwALy9ssERERERERERGRRvgQ8C3gtKSJpmZmZirZGhERERERERERERERERERERHpnqTX7oiIiIiIiIiIiIiIiIiIiIiIJFLjExERERERERERERERERERERHJTI1PRERERERERERERERERERERCQzNT4RERERERERERERERERERERkcz+H/ZYr1LtfdeHAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$\\displaystyle \\left\\{ {\\gamma}_{0,0,0} : \\frac{L {\\gamma}_{1,0,0}}{C}, \\  {\\gamma}_{0,0,2} : {\\gamma}_{0,0,2}, \\  {\\gamma}_{1,0,0} : {\\gamma}_{1,0,0}, \\  {\\gamma}_{1,0,2} : {\\gamma}_{1,0,2}, \\  {\\gamma}_{1,1,0} : \\frac{C {\\gamma}_{1,0,0}}{L}, \\  {\\gamma}_{1,1,2} : \\frac{C \\left(- C \\left({\\gamma}_{2,0,0} + {\\gamma}_{2,0,2}\\right) + L \\left(3 {\\gamma}_{0,0,2} + {\\gamma}_{2,1,0}\\right)\\right)}{2 L^{2}}, \\  {\\gamma}_{2,0,0} : {\\gamma}_{2,0,0}, \\  {\\gamma}_{2,0,1} : \\frac{- C {\\gamma}_{2,0,0} - C {\\gamma}_{2,0,2} + L \\left({\\gamma}_{0,0,2} + {\\gamma}_{2,1,0}\\right)}{2 L}, \\  {\\gamma}_{2,0,2} : {\\gamma}_{2,0,2}, \\  {\\gamma}_{2,1,0} : {\\gamma}_{2,1,0}, \\  {\\gamma}_{2,1,2} : \\frac{C {\\gamma}_{1,0,2}}{L}\\right\\}$"
+      ],
+      "text/plain": [
+       "⎧                L⋅gamma[1, 0, 0]                                             \n",
+       "⎪gamma[0, 0, 0]: ────────────────, gamma[0, 0, 2]: gamma[0, 0, 2], gamma[1, 0,\n",
+       "⎨                       C                                                     \n",
+       "⎪                                                                             \n",
+       "⎩                                                                             \n",
+       "\n",
+       "                                                                     C⋅gamma[1\n",
+       " 0]: gamma[1, 0, 0], gamma[1, 0, 2]: gamma[1, 0, 2], gamma[1, 1, 0]: ─────────\n",
+       "                                                                            L \n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "\n",
+       ", 0, 0]                  C⋅(-C⋅(gamma[2, 0, 0] + gamma[2, 0, 2]) + L⋅(3⋅gamma[\n",
+       "───────, gamma[1, 1, 2]: ─────────────────────────────────────────────────────\n",
+       "                                                                  2           \n",
+       "                                                               2⋅L            \n",
+       "                                                                              \n",
+       "\n",
+       "0, 0, 2] + gamma[2, 1, 0]))                                                  -\n",
+       "───────────────────────────, gamma[2, 0, 0]: gamma[2, 0, 0], gamma[2, 0, 1]: ─\n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "\n",
+       "C⋅gamma[2, 0, 0] - C⋅gamma[2, 0, 2] + L⋅(gamma[0, 0, 2] + gamma[2, 1, 0])     \n",
+       "─────────────────────────────────────────────────────────────────────────, gam\n",
+       "                                  2⋅L                                         \n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "\n",
+       "                                                                             C\n",
+       "ma[2, 0, 2]: gamma[2, 0, 2], gamma[2, 1, 0]: gamma[2, 1, 0], gamma[2, 1, 2]: ─\n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "\n",
+       "⋅gamma[1, 0, 2]⎫\n",
+       "───────────────⎪\n",
+       "      L        ⎬\n",
+       "               ⎪\n",
+       "               ⎭"
+      ]
+     },
+     "execution_count": 148,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Don't want the C=0,L=0 solution when using solve\n",
+    "#en_soln2 = en_soln[1]\n",
+    "#en_soln2\n",
+    "# If using linsolve\n",
+    "for tmp_soln in en_soln:\n",
+    "    en_soln2 = {g:v for g,v in zip(soln_var, tmp_soln)}\n",
+    "en_soln2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 149,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAC8MAAAArCAYAAADmSbsBAAAABHNCSVQICAgIfAhkiAAAIABJREFUeJzt3X+wN1dd2PH3E0J+YEKFYBqQWEaLhCEhMQFak8IEqKLSsREZEBvSR1PboZ2CULWCll76Y9CiA2aAWtvRWyKjrSiWFAwjCYoQfgYDiTgJAVoIMAJ9IgGRhED6x/l+59m7d3+c3T1nf33fr5k793nuPfu9u58953N+7H73e2Rvbw9JkiRJkiRJkiRJkiRJkiRJkpbkhKl3YGTPBT4A3Az8GfBj0+7O6OZ0/DcAHwJuAV6a6DXPBv4I+MjmtZ+R6HW1W+ZYj/rs0xyPY86MV3/GbnrmiPkwrukZU0manrm4P2OXxxRxHWvMbZ3pxhgPZzz6M3Z52b7HYczSM6Z5GFdJfZg7lJpj1PyMV3rGdBjj15+x68Z4aSo57uGdzJEdejL8jwE/Dvww8DngwcAPAvsT7tOYYo//TOAs4MOZ9+eBwF3A/YB3As8Dbhr4mg8l7P+HNt9vBB4FfGXg62q3pKxHDyPU8U9NsE+2h26MV3/GbnrmiPkwrukZU0manrm4vyXG7ruBd0+9Ey26xHVp8/Il1pkpGePhjEd/xi4v2/c4jFl6xjQP4yqpD3OHUnOMmp/xSs+YDmP8+jN23RivdVrC9ZYc9/Dm9D3AH9b9svxk+AcBfwF8R849GsEbgBcV/n8asAc8m3AjOMAxDt4IvtZjh7jjB7g/8ALy3wgPoREBnLT5SuGzhE4BwnHeCTykx+uspS4sVVUdHlOqenQqcCXDL7j33adUx7ErjFd/xm565oj5MK7pGVNJmp65uL8lxu4e4JlT70SL2LgucV6+xDozJWM8nPHoz9jlZfsehzFLz5jmYVwl9WHuUGqOUfMzXukZ02GMX3/GrhvjtU5LuN6S4x7enD4J/ETdL8s3w78EuBb42IA/+A7gdQO2T+HfAT8P/I3N/58FvB/4TMM2KY4dpj/+8rFD3PFDqChvSbQf5wOvB+4Avgp8ArgaeEyhzHsJCfxtpH9HyeMIN/f3ueCZqi6on6o6nFpM/YT6ehTTzl8E/Hbh/y8mtMO7gM8D1wDn9tj3PnV7SHvYRcarP2NXL1UOaGOOaPcvCG/8u2vz9W7g6Rn+zq7FdQzG9KCx8oqOM+bjM+bzYy7ubymxuxF4Ennn5BA3L4+ZezfFtTwvhzR5Zawx91LqTApLOi9rZjz6M3b1bN/jmCrOa2ZMuxlz7mZclZMxH5e5Iw/rcTOv2Y/DsVR6xnR6xq+/XYqdbbW7NY9dcl5viY1bzHWWnPfwpnYr8GjCJygcUrwZ/gGEm6H/24A/dgS4gHAiu9gnPLm8r/uX/v9hwkW0yzf/P5fmp52nOHaYx/GXjx3ajx/C07KeA7xrwH5sXUGIwd2Ep9F/5+ZnAM8vlPs7wLcSYtaWxMrnuKnMGYRGfCVwX8fXTVUXprTPsPo0tao63GSfbscbWz/r6lFMOz+D8FEnHy387FLgtcDFwFOAewmdyINb9rdYR2Pr9tBtdlGK/LGrdj12+8TloEsZngPayvQ5B122mbN94vuCO4CfBS4iTCSvB34feGzDNl3OA+xO7t0n7Ri+qcwu5Zh95pNXYuxKvMGYp7LP8mK+Nl2PfW3jhiF2JXZvAv51h/L7pJ+Xx8696+JaNS+Hfnllinn50upMnX3GGdc4F+pvF8fbW/sYuyH2sX3ntk/ecbPrGM0uZby6O2f7zGuNYi1xjXUp85gTL73td3EpeWLedy65VPuYO1LbZx7raXO2z3j1blfn+fvMcyxl3W22q+PTOn3HQGuI3z7Gboh9bKtd7DPemsbc5brecintcYu9l7nLPbxz8Abg56p+UbwZ/unAN4B3DvhDjwROp/vN4F08nNDYf5TwzoW7CTdxl71pUwbgrzj8FPyiFMcO8zn+4rFD+/EDfA9wS4L9uxj4deCngR8n3Fz/SeBPgOcS3pVSdBfhJrTvK/ws5hjrypwMvBF4OXBD5DZFVXXhVuB9wGmlstcB/4Vlm+uxletwKrH1s6kexbTzZ3I4nzwN+A1CO7t58/e+BbikUKapjtbtU+pttuZaN1LIlT+2jF3cNnXWGr+hOaCtTJ9z0LTNWs8DwP8ifBLOR4HbCIPkLxFuloJh5wHMvXWmGt+tOaa580qVXa/Hxnx8Y8V8zTHsOhZz3HDcLsfu7YRPGTyS4bVj5+Vtc++muEL1vBza88oc5uV128y1vqQwJN87F4rnekh/xq4/2/c4xu7ftnY5pmA9LBpj7uYYyXWIMaSIeaq5ZNFaY27uyCNVXNcaozlds19rjGH8eUDRWuPq+LS7VGOgXWzDxq4/22p3Q9Y0tuYcn1zXW2LqWpd7mavu4Z1rXN8N/CBwv/IvTiz8++8RDnzIu0ouItxInPNx+Rdsvv8U8BLCjUx3VpR7L+HmplOBPyCc/FcDXyCc5MsIH78MaY4d5nP8xWP/a9qPH+AHgA8m2L9XERLyK2t+f4zw0Q8nET6i4RTge0vlY46xqsxfEt4dcz0Hj63L61bVhWcB7yG8o+Z/b352GeF8Ny1eLMFcj61ch1OJqZ9HaK5HMe386cBrWvbldMKbVI4VflZXR5v2KeU2RXOtGynkyh9bxq59m7rYwbrjV9QlB9BSps85aNtmV87D/QjHehrHJ5R9z4O5t9lU47s1x7QsZV6py9O7Xo/LjPn4csV8zTHsOhZz3HDcLsfu64T1owtJ/8CHmHk5NM+92+btEDcvh8N5Zep5edM2c60vOcTme+dC3bge0p+xS8f2PY6c/VvRLscUrIdNUs/dHCMFrkOMr0/MU8wldzXm5o48+sZ1V2I05TX7XYkx5J0HWHePc3x6UIox0K62YWOXjm21u9g1jaI5xyfn9ZaiqrrWdo9j2z28c43rfcCnCQ+8PPBQpOLTwh8BfGbgH7qQ8ITNLw98nSbnE26OfSZwLfCxzc9+qlTuM4SPRHgY4SLbKwgJ4+bN/08ulH0Ew48dpjv+c4CXFsoUjx3ajx/gCcDtA/ftHODxtF9sfBBh3z8MfAD4Y443GKg+xmPAkzl+nqvKPJrw8dqXERrxTcB5La9bjt0jOFwXPkR4o8A5m/+fBPwS8O8Jcfwj4CObcs9oOXYIbzy4lZCc/3nCsn2kPLbYfT074nXLdTiF2Pp5Cc31KKadX0yIRZNXbV77PYWf1dX9pn1Kuc3FHG8PTXXjc4Sn999J+OiRGCnrx1Cp8kex7+kSu67HOKeckSp2xZxejB3MNy+l1iUH5Oj/2rZJmQO61MuxzsV5hDx+N+Gjoy4jjJGg/3kYI/d2beNzagNTje9S5+RcdT+FlHmlLk+nqMdL7gfLUsa8blwxNOY55ytz7j/LawRDcwXka/9TjN+axmKpxw25xm9dy/YR057b2utcYxfTfm/l+CfnpBI7L4fmuXfbvB3i5uVwOK9MPS9v2iZlH5urbCqx+X7sudDS+9Wp10PWNp9JuR7ivGVZ7btPnZs6zlOtY1h35zP+61N+iNRrFEPGSEu+llGWck6cax1i6X1+WZ+Yp5hL5lz7ydUmUphT7tjFPqwc16muE805PmPO85c+/yzLOQ8o3/MzRd1dckzX3K+nGAMN6UsgT/6bw3Xd3LHbxX54rmuWXcumELum0WWOAtOOXXJcbymrqmtt9zi23cM71XgwpvzthOtNBxzZ29vb/vutwP8B/lnh93vAv235w08mNCgIN1t/Bri8ZZuXbL62TibcsX9P4WffT/iI5LLf2ZR9VsvfeCThZJ5H+DiAJlXHDss9/i7HvvVp4B8SKnbRHvEx+BHgtzZ/f8iN9THHGFsPum5TVxd+A7gX+AngZ4B/ApwLnAGcSWj8ZxLewfMo4Cs1r38i8OfAU4D/R4j3U4HPDig7pD6lOrYux/XQiNdtqsN9jzdV/Wxr5/cn3Fx5BvXvjHzFZvsnlvYlV73uu01d3biH0O5PA/4xYcDRJHX9gO75uWiMODfFLvYYIU/O2GPesYN55qWtoTkXhuWAsc4BpMkBXc4DxJ+LoefhJODbgG8GfnhzjJcS+pypz0Nd3L9Bt1jmaAO5x7C54poqJ0Oeur+kvJJiDDF1P5gi3rCcmOecr4yVs7dyx7yp3kKe9t+l7B79xnBdc2vqcUOu8ZuxOyjHmOsq4IvAv6nYfox5eewaW5WYeTlU55W5zcvLUvWxucpOPa4pm7Jdwvz61SnXQ3ZhPjN0G+cty2nfXc/HHOYqU60hT1135zAXqTLF+G/MmI299gnrvZZRtJR1iDn0+XtMG/Ncc8lUY9QcbWKNucM+LBj7OpHj0/XMP4umiPPYdXfJaycw7359rLl8jr4kV/7bhdhN3Q/DstrqGu5d3BqypjHn63w5rrcU1dW1IddZtqa4byim/K8Q3iTxs8UNi0+G/wLhbv+iVxPeedL09b5C+e8i7nH+v0r4CIPt15sqfla+KXvrfA5PTq/h8BOgHrz5/vmI/ak6dljO8b8BeFzh/12OfeshwJcqft4lBqduvg99Mn7VMcLB81xVpu4d9U2vW45dXV24ldBR/E3g54B/RWjUnyV0JhDe8XInIZZ1nkB4J9anCJ3OG4F/MLDskPqU6ti6HFfM6zbV4b7Hm6p+trXzhxA+7qeqPQH8MnAFIUmXL/7X1f1i3S6L2abqaY9V25TbQ13dAHg79cdYlrp+QPf8XNSWP2K3KeakLrHL1bZiy6aOHfSro9v4lWMH88xLW0Nzbp8c0Nb/Qf3TXZu2qSpblCIHdDkPEH8uhp6Hewjx/wDwYsI7ZH9y87sU5wHS596usczRBlKPYWGc8V2qnAx56v5c80pVnk4xhpi6Hxwab8gT87pxxdCY55yvjJWzoXvMy2sEQ3MF5Gn/Xcr2HcN1HYtVlW8bM8D447c5xA7i2mvfMVeu2BH52ncB31Kz/Rjz8tg1tipt83KozytTz8uHjNG71JlcZacY1ww5N3XxXmu/OuV6yFrnMynXQ5y3HNYnvmP0u7lyQc5xc8oYL6nuTjX/a8utU4z/xopZ7rVPqG7na72WsZVjTpxrHWIOff7UMU81l8y19pOjTcw1d4w1v4L19GHl/DH2daIljU9zz/OXPv/c6hrnFNeEYPy6u6S1ky5jqTn06znvL8y5tgv58t8cruvmjt3U/TBM01bn2GfMYeySYn0Cph275LjestVU14ZcZ9ma4r6hmPJfoiKmJxb+/afA0dLvv7D5ivHthKdrfjCi7LHNV3HnjtH+VKhvAr6DsK9Fj+LwRx+fR3hnw19E7E/VscNyjv8xhAqw1eXYt/6K8M6Ssi4x2D7B+0nA/6z4/QOof9fRVt0xwvHzXFfm7ZsvgBs2X22vW45dXV24DXgh8B8JCyTXVJR5HOHpY5+q+N3Ww0q/vwP41oFl+9anrRTH1uW4Yl63qQ73Pd4U9TOmnW9f4yTCO6OKriJ8rM2TOVjvoLnuF+t2n22K7aFpm3J7iKkbMVLXD+iWm4pi8kfsNsW+p2/sUrat2LKpYwf96ug2fuXYwTzz0taQnNs3B7T1f3C4zce8brmvLEuRA/qeB2g+F0P7vrITgFNIfx5S5t6usczRBlKPYWGc8V2qnNxFl/jPNa+U83SOMcQU/eDQ/JEr5lXjitQxTz1fiX3tKWJejGfqXNEmR72FfmO4rmOxuvJtYwYYf/w2h9hBXHtNMebKNfZteu2TqZ8j556Xd1ljq9I0L4f6vDKHeXmqMXqXcU3KslOMa1Kcm7I19qtTr4esdT6Tcj3EecthfeI7Rr/btezUc5XUMV5S3Z1q/teUW2Ga8d8YMRtz7bPcztd4LWMr15w41zrEHPr8KWOeci6Za+2ni6XnjinmV23m3oeV77sZ+zrRksanY87zlzb/3OoT5xTXhGDaa5xzXzvpMpaaQ7+e8/7C3Gu7ufJf0VTXdcdaF4fdWgeZY58x9dhl7ve4xZbNcb0Fmuva0OssW1P0qTHlT6HiwUvFJ8O/lfBO6KZ3hjS5aPP9a4RH4W+/Ht3z9ao8dvP9w4WfnQ58lYPv5IBwYe3ayNcdeuww3fE/YPO92GC6HPvW54AH9tyvrfcDbyG84/4o4WOv/zah0V1HeKdOm6pjhIPnua5M01OJYmNXVxduI3yUyBUcf3Js0RnA64ArCR9VUedIxc/qyncpO0SKY+uzr02v26cOt0lRP2Pa+RcJH8debk+v3fzd5xA6rbM2X6dtfl9Xr6H60y+6bFNsD3XbVLWHtroRK3X9GCImf8RsU8xJfWOXum3lzhkp6+g2fts35ZUHfXPMS0P1zQEx/R/UP1muaZuqJyUUpcgBfetlznPxC4SPh3oEIWYvBy4FXk+68wDpc2/XWM6pDUw9vkuVk7sYYxyXM69U5enUY4il9YOQL+Z144qUMc8xX+n62n30iXl5jSBlrogxp3rbdSxWV75tzADjj9+mjl1se4XhY65cY9+2134g3R6yECN2Xj50ja1uXg7NeWXqeXm5XJXU45pcZbuaas2kLt5r7FenXg9Z43wG0q6HOG85rE/7HqPf7Vp26jinjLFz7mF1d2uK8V/umI219gnV7XyN1zIg35w45zrEkvt8GB7zVHPJnGs/XSw9d4w9v4ox5z6s6r6bsa8TzTk+MM08f4nzT+gf5xTXhGC6a5xzjCn0H0stuV9PMQaCYW04d/6b6rpuzLVDsB/u01bn2GdMHbO53+MWWzbH9Za2upbqXuYp+tSY8pUxLd4MfzPwXuBH2vauxoWb7+/avNb2q+pJT32dD3yU8BTzrXOBPyuVOxW4DPivka879NhhPsff9di3bic0iKGeAfwS8CLgJsKFzp8hxKXqXTplVccIB4+zrkzTU4li605dXbgd+AbwaxXbnEz4OIaX0/60vE8DZxf+/3DCE9CHlh0ixbF13dem1+1bh2MMrZ+x7fzjHG5PzyMMDq8jfETN9mv7cVR19RqqP/2iyzbF9hDTxraa6kYXKevHUDH5I2abYrz6xC5H28qdM1LW0W3MqmIH88tLKfTNATH9H9Q/Wa5pm6onJRSlyAF96mXuc3EW8JuEeF0HPB74fuAPSHceIH3u7RrLObWBqcd3qXJyF2OM43Lmlao8nXIMscR+EPLFvG5ckSrmueYrXV+7jz4xL8cnVa6INad623UsVle+bcwA44/fpo5d+d+5xly5xr4xr30W8LGW1+gjZl6eYo2tal4OzXll6nl5uVyVlOOaXGX7mGrNpC7ea+xXp14PWeN8BtKuhzhvOaxP+x6j3+1aduo456jDRdbdw5pyK0wz/ssds7HWPqG6na/xWgaMMydOvQ6x5D4fhsc81Vwy59pPF0vPHWPOr2LNuQ/LtV42p/UeSNfHjzHPX+r8E/rHOcU1IZjmGudcYwr9x1JL7tdTjIFgWBvOmf+mvK5rP9xsSFudY58xdczmfo9bbNkc11va6lqqe5mn6FNjyp9FqBsHnFD6/8uA5wP3i93TghcT7sovfzU9/WDrKLAXUe5XgXNKPzuXcKKKrgTes/mKNeTYYbrjfywHj7/PsUN4CvcFHbepcjfwnzb79U3AgwjvNHkp4R1ibaqOEQ6e56oybU8liondVlVdOInQXl5XKnsE2AeuB66ueK3rOPgxDe8jdF5nE276/iHgzT3KNjlKXH3a6nNsQ46rLWZd6/BR4o93aP2MbedV7alquyOFfa+r+3WffhG7Tbk91G1T1R7q6kabnPVjqLb8EbtNMSd1jV2uttU3Z8RKWUe38avLw3PLS02OEpeD+uaAtv4Pmp8sV7dN3ZMSivrkgK71MtW5OEp8X3AU+FuECeGZwN8nfDIMpDkPuXJv11iO0QaO0n8MC+ON71Ll5CYpc/JRps8rVXk61Rhibv3gUeLzR66Y140rUsQ853xljJzdJ+blNYIUuaLJEsdvdWOxqvIxYwYYf/w2dewgrr0OGXOlil1V+Zj2ey7wtob9LjpK2nn5kDW2rbp1rqa8MvW8fOgYvUudSVW2zVHyjmuGnJu6TyqDNO0S5tWvTr0essb5TOr1EOctB/WJ71j9bsoxdpOjpBk3p4zx0uvuUfLP/9pyK0wz/ssdszHWPuvWh2Cd1zK2fyPHnDjnOsQc+/wuhsY81Vwy1dpPl1xbVX7JuWPM+VWTJfVhVffd5L5OtNTx6Rjz/F1c1015z8/YdXcpayddx1Jz7NePkub+wtxru5Au/80hdtDt2uHa+mHI31bHWtOAZV1/nfs9brHxyXG9pa2upbjOAuP3qW3lt84F/rD8h8s3w7+V8FHFD++w81M7D7il9LN7gH/Z8XWWeOwQjr/YuPscO4SPxXl8kj3Ko+o8F7U9lajuNasGxlV14XzCu1zK+3AJ4eO8LyM80ewmjieNI4SP+z5WKH8v8EJCQ74Z+M+Ed650KZta12MbelxNMYP+dXhOfh/4u4leK7Y+120zpD3U1Q0InfTvAD8A3AF89+bnuetHDn1iXMxJXWOXq22NlTPKhsSvLg/PLS9Nqa3/g/Yn7Tdt06RrDuhaL5d0Lrqch/K/2143Nn90jeUS2sBY47tUORnS1P2pxdTntjxdLrvL/WCMtpi3jSuqysfGPOd8Zck5u2u9heHtf071tksbj82/Y4/fpo7d9t8p4pczdtSUb2u/DwU+Afxly77P2RLn5UPH6F3qTIqyczDk3DRtm6Jdwvz71THXQ9Y4n0m9HuK85aChubdOivadaow9tb512LrbbK7jv7nGLNWa265cy4jRZd1n+++U6xBr7PPbTB3zFLmWmvJryR117MMOqoprzutES4vP2PP8XVzXTXnPz9h1d64xhWFjqbX162Ou7UKa/DeX2EH66wr2wweNNZeEdfTNS7rOt/TrLWP3qU3ltx5GeNL+oZieWP4BcFXDwc3R8yt+9ms9X2tpxw7wROAXCv/ve+z/l1ApH0r4yIS5qTrPRW1PJapSjl1RuS6cD9zG4XdgvZPDbyrZOgf4XeCvSz+/ZvPVt2xqXY/t0Qw7rqaYQf86PCfvAH6S8O6opifAxKh6F36XbYa0h7q6AeFJylWG1vu2+pFDnxgXc1LX2OVqW3VlcxsSvz2q8/Dc8tKU2vo/aH/SfpWYsl1zQJfzAMs6F13OA+TLvV1iWVd+TnEfa3yXMienqPtTi6nPbXm6aNf7wRhtMW8bV5R1iXnO+cqSc3bXegvD2/+c6m2XNh6bf8cev9WVza1rex0y5koRO+jXfv8R8B8afr8ES5yXDx2jd6kzKcrOwZBz0xTvVO0S5t2vjr0esrb5TOr1EOctB/WJ71j9bqox9tT6xNg5d7uYuE4x/msqP6VUa267ci0jRpd1H0i/DgHr6/PbTB3zFLkW1pc7xpxfwTr6sKq45rxOtKQ6B+PP83dxXTflPT9j1925xhSGj6XW1K+Puba7NTT/zSV2kP66gv3wQWNeS4Dl981Lus639OstU4wH68pv/Sg1MT2yt7dXs41m7hTgBsLHPr8k0Wt+G/Ac4BcTvd6YriK82+RNwK8Afwz8Xk3ZHLGTyp5ASPD/feDrFOt2n21sD+36xBiM3Vaf+Bm7tLbn4Kk0t/eittyg7sy96RnT6cTE05inZczHYQyDLnFwzHDY2uN3MmER+YVT70gCS5mXby2xvkxtyLnpMn9aK9dDhnE9JK8+8TWPdtMlxtbdeH1zq+r1GVepnesQ4zPm4zJfKDXn+fl5TSgPx1IHrX1tNydjl5cxi7O0/L+m6y1z0RhTb4ZX2dOAjwMfnXpHBvgg8HTm+YR77ZZnA9cDn59wH2wP0u7o0t7NDXkZ3/SMqSRNw/w7zBLjdznwZuDOqXckkSXNy5dYX5bMeEvrY7uW1s92LimW+UI5Oc/Pz9jlYVy7MV79GbvujNk6re16yxxcDrwFOFb1y7l+TIum81bgjql3oqdTCJ3Dtdg5aB7+B/Clif627UHaHV3au7khL+ObnjGVpGmYf4dZcvzewLoWZpcwL19yfVki4y2tj+1aWj/buaRY5gvl5Dw/P2OXh3Htxnj1Z+y6M2brtrbrLXPwu9TcCA8+GV6SJEmSJEmSJEmSJEmSJEmStEA+GV6SJEmSJEmSJEmSJEmSJEmStDjeDC9JkiRJkiRJkiRJkiRJkiRJWhxvhpckSZIkSZIkSZIkSZIkSZIkLc6Jm+/3TboXkiRJkiRJkiRJkiRJkiRJkiR1sL0Z/sikeyFJkiRJkiRJ0m47G7gaOBP4GvAy4Pcm3SNJkiRJkiRJkmbuxPYikiRJkiRJkiQps3uBFwAfItwQfyNwLfCVKXdKkiRJkiRJkqQ5O2HqHZAkSZIkSZIkSXyWcCM8wOeAO4GHTLc7kiRJkiRJkiTNnzfDS5IkSZIkSZJU78XA+4G7gM8D1wDnVpQ7H3g9cAfwVeATwNXAYwpl3gG8LuJvPg64P/Cp3nstSZIkSZIkSdIO8GZ4SZIkSZIkSZLqXQq8FrgYeApwL/A24MGFMlcANwJ3A88GvnPzM4Dnb74fAS7YlGtyBuGG+SuB+wbvvSRJkiRJkiRJK3bi1DsgSZIkSZIkSdKMPa30/+cCXwQuITwl/mLg14GfBl5ZKPdJ4E84ftP8I4HTab4Z/mTgjcDLgRuG7rgkSZIkSZIkSWvnk+ElSZIkSZIkSYp3OmFt/djm/68i3Lj+ypry23IXAd8AbqopdwTYB64Hrk6xo5IkSZIkSZIkrZ03w0uSJEmSJEmSFO9VhBva3wOcAzweeE3EdhcCtwFfrvn9JcCzgcs2r38TcN7QnZUkSZIkSZIkac1OnHoHJEmSJEmSJElaiFcATwKeCHwduGDz8xsjtr2opdw78QE2kiRJkiRJkiR14sK6JEmSJEmSJEntfhm4AngqcPvmZ6duvtc97b3ou4i7aV6SJEmSJEmSJEXyZnhJkiRJkiRJkppdBVwOPBn4SOHnt2y+P6lmuwdsvn878M3AB7PsnSRJkiRJkiRJO+rEqXdAkiRJkiRJkqQZey3hRvjLgGPAWZuffxl4P/AW4NWEG9/fBdwHXAT8U+DngXdv/g/wNeDcwmt/HfjzxCsVAAAAwUlEQVTzvLsvSZIkSZIkSdJ6eTO8JEmSJEmSJEn1nrf5fl3p5y8D9oBnAC8AXgS8BrgH+DjwZuBPN2Uv3Hx/V+k1bgHOS7u7kiRJkiRJkiTtjiN7e3tT74MkSZIkSZIkSZIkSZIkSZIkSZ2cMPUOSJIkSZIkSZIkSZIkSZIkSZLUlTfDS5IkSZIkSZIkSZIkSZIkSZIWx5vhJUmSJEmSJEmSJEmSJEmSJEmL483wkiRJkiRJkiRJkiRJkiRJkqTF+f8+ZeBixc88eQAAAABJRU5ErkJggg==\n",
+      "text/latex": [
+       "$\\displaystyle \\frac{\\left(- L + r_{i}\\right)^{C} \\left(- L + r_{j}\\right)^{C} \\left(- C^{3} r_{i} r_{ij}^{2} r_{j} \\left({\\gamma}_{2,0,0} + {\\gamma}_{2,0,2}\\right) + C^{2} L \\left(2 r_{i}^{2} r_{ij}^{2} r_{j} {\\gamma}_{1,0,2} - r_{i}^{2} r_{ij} {\\gamma}_{2,0,0} - r_{i}^{2} r_{ij} {\\gamma}_{2,0,2} + 2 r_{i} r_{ij}^{2} r_{j}^{2} {\\gamma}_{1,0,2} + 3 r_{i} r_{ij}^{2} r_{j} {\\gamma}_{0,0,2} + r_{i} r_{ij}^{2} r_{j} {\\gamma}_{2,1,0} + 2 r_{i} r_{ij} r_{j} {\\gamma}_{2,0,0} + 2 r_{i} r_{ij} r_{j} {\\gamma}_{2,0,2} + 2 r_{i} r_{j} {\\gamma}_{1,0,0} - r_{ij} r_{j}^{2} {\\gamma}_{2,0,0} - r_{ij} r_{j}^{2} {\\gamma}_{2,0,2}\\right) + C L^{2} \\left(2 r_{i}^{2} r_{ij}^{2} r_{j}^{2} {\\gamma}_{2,2,2} + 2 r_{i}^{2} r_{ij}^{2} {\\gamma}_{2,0,2} + r_{i}^{2} r_{ij} {\\gamma}_{0,0,2} + r_{i}^{2} r_{ij} {\\gamma}_{2,1,0} + 2 r_{i}^{2} r_{j}^{2} {\\gamma}_{2,2,0} + 2 r_{i}^{2} r_{j} {\\gamma}_{2,1,0} + 2 r_{i}^{2} {\\gamma}_{2,0,0} + 2 r_{i} r_{ij}^{2} {\\gamma}_{1,0,2} - 2 r_{i} r_{ij} r_{j} {\\gamma}_{0,0,2} - 2 r_{i} r_{ij} r_{j} {\\gamma}_{2,1,0} + 2 r_{i} r_{j}^{2} {\\gamma}_{2,1,0} + 2 r_{i} {\\gamma}_{1,0,0} + 2 r_{ij}^{2} r_{j}^{2} {\\gamma}_{2,0,2} + 2 r_{ij}^{2} r_{j} {\\gamma}_{1,0,2} + 2 r_{ij}^{2} {\\gamma}_{0,0,2} + r_{ij} r_{j}^{2} {\\gamma}_{0,0,2} + r_{ij} r_{j}^{2} {\\gamma}_{2,1,0} + 2 r_{j}^{2} {\\gamma}_{2,0,0} + 2 r_{j} {\\gamma}_{1,0,0}\\right) + 2 L^{3} {\\gamma}_{1,0,0}\\right)}{2 C L^{2}}$"
+      ],
+      "text/plain": [
+       "         C           C ⎛   3        2                                         \n",
+       "(-L + rᵢ) ⋅(-L + r_j) ⋅⎝- C ⋅rᵢ⋅r_ij ⋅r_j⋅(gamma[2, 0, 0] + gamma[2, 0, 2]) + \n",
+       "──────────────────────────────────────────────────────────────────────────────\n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "\n",
+       " 2   ⎛    2     2                        2                         2          \n",
+       "C ⋅L⋅⎝2⋅rᵢ ⋅r_ij ⋅r_j⋅gamma[1, 0, 2] - rᵢ ⋅r_ij⋅gamma[2, 0, 0] - rᵢ ⋅r_ij⋅gamm\n",
+       "──────────────────────────────────────────────────────────────────────────────\n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "\n",
+       "                      2    2                           2                      \n",
+       "a[2, 0, 2] + 2⋅rᵢ⋅r_ij ⋅r_j ⋅gamma[1, 0, 2] + 3⋅rᵢ⋅r_ij ⋅r_j⋅gamma[0, 0, 2] + \n",
+       "──────────────────────────────────────────────────────────────────────────────\n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "\n",
+       "       2                                                                      \n",
+       "rᵢ⋅r_ij ⋅r_j⋅gamma[2, 1, 0] + 2⋅rᵢ⋅r_ij⋅r_j⋅gamma[2, 0, 0] + 2⋅rᵢ⋅r_ij⋅r_j⋅gam\n",
+       "──────────────────────────────────────────────────────────────────────────────\n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "\n",
+       "                                                2                          2  \n",
+       "ma[2, 0, 2] + 2⋅rᵢ⋅r_j⋅gamma[1, 0, 0] - r_ij⋅r_j ⋅gamma[2, 0, 0] - r_ij⋅r_j ⋅g\n",
+       "──────────────────────────────────────────────────────────────────────────────\n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "\n",
+       "             ⎞      2 ⎛    2     2    2                      2     2          \n",
+       "amma[2, 0, 2]⎠ + C⋅L ⋅⎝2⋅rᵢ ⋅r_ij ⋅r_j ⋅gamma[2, 2, 2] + 2⋅rᵢ ⋅r_ij ⋅gamma[2, \n",
+       "──────────────────────────────────────────────────────────────────────────────\n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "\n",
+       "          2                         2                           2    2        \n",
+       "0, 2] + rᵢ ⋅r_ij⋅gamma[0, 0, 2] + rᵢ ⋅r_ij⋅gamma[2, 1, 0] + 2⋅rᵢ ⋅r_j ⋅gamma[2\n",
+       "──────────────────────────────────────────────────────────────────────────────\n",
+       "          2                                                                   \n",
+       "     2⋅C⋅L                                                                    \n",
+       "\n",
+       "              2                          2                           2        \n",
+       ", 2, 0] + 2⋅rᵢ ⋅r_j⋅gamma[2, 1, 0] + 2⋅rᵢ ⋅gamma[2, 0, 0] + 2⋅rᵢ⋅r_ij ⋅gamma[1\n",
+       "──────────────────────────────────────────────────────────────────────────────\n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "\n",
+       "                                                                              \n",
+       ", 0, 2] - 2⋅rᵢ⋅r_ij⋅r_j⋅gamma[0, 0, 2] - 2⋅rᵢ⋅r_ij⋅r_j⋅gamma[2, 1, 0] + 2⋅rᵢ⋅r\n",
+       "──────────────────────────────────────────────────────────────────────────────\n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "\n",
+       "  2                                              2    2                       \n",
+       "_j ⋅gamma[2, 1, 0] + 2⋅rᵢ⋅gamma[1, 0, 0] + 2⋅r_ij ⋅r_j ⋅gamma[2, 0, 2] + 2⋅r_i\n",
+       "──────────────────────────────────────────────────────────────────────────────\n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "\n",
+       " 2                            2                          2                    \n",
+       "j ⋅r_j⋅gamma[1, 0, 2] + 2⋅r_ij ⋅gamma[0, 0, 2] + r_ij⋅r_j ⋅gamma[0, 0, 2] + r_\n",
+       "──────────────────────────────────────────────────────────────────────────────\n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "\n",
+       "      2                       2                                      ⎞      3 \n",
+       "ij⋅r_j ⋅gamma[2, 1, 0] + 2⋅r_j ⋅gamma[2, 0, 0] + 2⋅r_j⋅gamma[1, 0, 0]⎠ + 2⋅L ⋅\n",
+       "──────────────────────────────────────────────────────────────────────────────\n",
+       "                                                                              \n",
+       "                                                                              \n",
+       "\n",
+       "              ⎞\n",
+       "gamma[1, 0, 0]⎠\n",
+       "───────────────\n",
+       "               \n",
+       "               "
+      ]
+     },
+     "execution_count": 149,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Final expression with all the constraints inserted\n",
+    "ftmp_out = ftmp.subs(sym_subs).subs(ee_soln).subs(en_soln2)\n",
+    "ftmp_out2 = simplify(expand(ftmp_out))\n",
+    "ftmp_out2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 150,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAg0AAAAZCAYAAACywB0wAAAABHNCSVQICAgIfAhkiAAABwFJREFUeJztnW2IFVUYgJ+bYUVrqUSERq1RQdKXJf0QNm6GEAm1SRJEhBAVLf2oiKQv2ILqhylqYNGvjSIqDQrLQIr2Tx+rSR+UWQZZtJWlVmb4udmPdybvnp2PM3PunJl7533gMnpn3jnznHfO3cO5Z85tDA4OoiiKoiiKksZxKftvBj4G/gLGgEsLvyJFURRFUXwzCBwGfgXeAM6POuj4hBPMBl4C/gHWAqPByRRFURRF6S6GgRORwYHrgRnAFeZBSZ2Gq4AG8DCwuv3XpyiKoihKRRgOXgBbgLlAD7Cv9aCkryemB9uv23xhiqIoiqJUl23IoME0c0dSp2FSsD0cs39RsG8EODvmmMeAo8AdVpfZWah/ff3r7A7qr/719a+Le/h3f5K5Y1Kz2YwLagavF4AdEfunAzODYyYDG4z95wAvA58CA0gldhPqX1//OruD+qt/ff3r4t6PzG1YBfzZuiNppGFqsN0fs/8D4AZkouTciP2rkUodAP7NcLGdgvrX17/O7qD+6l9f/7q4Hwi2p5o74joNDaAP6SX9kHDig8BW4ALj/euAhcDzwCdZrrTDUP/6+tfZHdRf/evrXwf3HcG2ae4wOw3XAMuBTcBliHzaY5bbgCnAmcH/TwJWAruAh4xjB4DvkV7MFqRjkgWX+AeBzcBe4HdgPXBhxvKjsPW/MijzZ6QzdmOOssqsvzhs/NvhDtXLv23u21F2p+Yeyvcvu+27ll+Fz44obPxd3duVu3b7+8p9WfEvIgMGTwOvAU8AvRDdabgPGXb5EnjG4uTbgu3sloucBSwF/mg57ibk+5EngTnIMM87wFkWZbQjvgmsAeYB84EjwLsce0okL7b+JwOfA3fnLKfs+ovDxt/VHaqZf9vcu5bdybmH8v1dy4/Dl3/Znx1x2Pg3cXN3jYdi/H3lvqz4UeApZELkYqQj1AvQiFhG+hRkjYZXgN3IDNGxhJMvAl4H7kV6MV8hk0DmMX4SyAjwBXB7y3vbgXVIhafhGm/Sg6x02R9cd15s/Vs5iiRiXYZyqlZ/IVn987hDNfOfJ/d5yu6W3If49nctPw5f/q2U8dkRRx5/17rPE1+Efxm59xm/EHgL6WDdCXxL8ERF1JyGvcCbSIXMZOL3NiatPa5VyIJR5qzRycDlwEYjdiNSyWm4xkcxBfHfkzM+xMbflSrWX0gn+EfRjvzndc9Sdjfm3qe/a/lJ+PB3pWr5d3XPGl+Uf1m59xU/P9gOIh2i/5deSHp6IpwAmTaM8R0yErEY6Z08i/S4WjkNed5zp/H+TuCMlPO3Iz6KlcBnyG9rmAwhyV9icR4bf1d81t8Q9u7QGf5RxOV/iOJzn3TvmfhuO0N0l3/W8oeolr8rVWv7ru5Z44vyLyv3vuLDRZ12mDuSlpEOexZpP2p1CJlgci7wG/BowrFmL6wR8V4SrvEhy5DJRX1Ef/USOh+xOFcWf1d81F8Wd+gs/5Ck/Bed+7R7Lw5fbadb/W3Lr6q/K1Vo+67uLvHt9i8j9z7jY+siqUOQpUGGQzVLMRaCCNiFXKTZszudiT3AKFzjW1kO3ApcjfQWo7gI+Bt42/Kcaf6u+Ky/rO5Qff9W0vJfZO5t7j0T322n2/yzll81f1eq0vZd3fPGF+nvM/dlxU/oByR1Gg4G2wlrT0cwDVnIYm3M/kPIYy4LjPcXAB9anN81PmQ1cAsy0XNrzDFTgYuB5xg/CzaJNH9XfNVfHneovn9IWv6LzL3NvReFz7bTjf5Zyq+ivytVaPuu7i7xRfr7yn0Z8eHf/QPmjqSvJ7YH29uQhSpGiV7hqgFcAnyDrJIVxwrk2c9NHJuROQNJkg2u8WuQiutHJoGEPc99jP8Vrz7kq5kVlue19e9BhrJCepFlOvcAP1qU46P+srqDnb+rO/jJf1G5t7334vDVdrrVv+y27+rv47OjqLbv6u4aD8X4+8q97/gTEK8mx9Z2GEfSSMMGZK2GhciNOYbcqCbnITd12iSQV4F7gEeQiRh9wLWMX3FyCTIc0ltA/F3IzNH3gF9aXvcbx61HflM8bVGrEFv/ucEx4XHLgn8/bnn9PuovqzvY+bu621x/WrxN/ovKvU3ZSdfvI/fQvf5lt31Xfx+fHUW1fVd313goxt9X7n3EhwwiIwsjyNILK4gYKEgaadiP3Kzzkccue4iu0DnB1mbm6JrgFccsZPjkpwLiGxbXlwdb/2GLayjS3yY+Dzb+w7i7Q/L1p8UXkX/b3NuU3a25h/L9y277rv7DFueoav5d3dtx70D7/X3l3kd8yDAy8XE38BHSwZp4wojFncpkM/AA8H5J8WVTZ/86u4P6q399/evsDh3mX7VOg6IoiqIoFSVtDQZFURRFURRAOw2KoiiKoliinQZFURRFUaz4D1qW7HWoj3pYAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$\\displaystyle \\left\\{{\\gamma}_{0,0,2}, {\\gamma}_{1,0,0}, {\\gamma}_{1,0,2}, {\\gamma}_{2,0,0}, {\\gamma}_{2,0,2}, {\\gamma}_{2,1,0}, {\\gamma}_{2,2,0}, {\\gamma}_{2,2,2}\\right\\}$"
+      ],
+      "text/plain": [
+       "{gamma[0, 0, 2], gamma[1, 0, 0], gamma[1, 0, 2], gamma[2, 0, 0], gamma[2, 0, 2\n",
+       "], gamma[2, 1, 0], gamma[2, 2, 0], gamma[2, 2, 2]}"
+      ]
+     },
+     "execution_count": 150,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Find the free gamma values\n",
+    "{a for a in ftmp_out2.free_symbols if type(a) is Indexed}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Formula from Appendix of the paper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 123,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of gamma values (after symmetry) :  18\n",
+      "Number of e-e constraints :  5\n",
+      "Number of e-n constraints :  5\n",
+      "Number of free param =  8\n"
+     ]
+    }
+   ],
+   "source": [
+    "NN_en = 2\n",
+    "NN_ee = 2\n",
+    "Nc_en = 2*NN_en + 1\n",
+    "Nc_ee = NN_en + NN_ee + 1\n",
+    "N_gamma = (NN_en + 1)*(NN_en+2)//2 * (NN_ee + 1)\n",
+    "print('Number of gamma values (after symmetry) : ',N_gamma)\n",
+    "print('Number of e-e constraints : ',Nc_ee)\n",
+    "print('Number of e-n constraints : ',Nc_en)\n",
+    "print('Number of free param = ',N_gamma - Nc_ee - Nc_en)\n",
+    "\n",
+    "# Note, for N_en=1 and N_en=1, this formula doesn't match the above derivation. \n",
+    "# For all higher values it does match."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 120,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0\n",
+      "k:  0  terms:  2*gamma[0, 0, 1]\n",
+      "1\n",
+      "k:  1  terms:  2*gamma[1, 0, 1]\n",
+      "2\n",
+      "k:  2  terms:  2*gamma[1, 1, 1] + 2*gamma[2, 0, 1]\n",
+      "3\n",
+      "k:  3  terms:  2*gamma[2, 1, 1]\n",
+      "4\n",
+      "k:  4  terms:  0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# For the electron-electron cusp\n",
+    "for k in range(0,2*NN_en+1):\n",
+    "    terms = 0\n",
+    "    print(k)\n",
+    "    for l in range(0,NN_en+1):\n",
+    "        for m in range(0,l):\n",
+    "            if l+m == k:\n",
+    "                #print(' ',l,m,'2*gamma[%d,%d,1]'%(l,m))\n",
+    "                terms += 2*gamma[l,m,1]\n",
+    "    # sum over l,m such that l+m == k and l>m\n",
+    "    # plus\n",
+    "    # sum over l such that 2l == k\n",
+    "    for l in range(0,NN_en):\n",
+    "        if 2*l == k:\n",
+    "            #print(' ',l,'gamma[%d,%d,1]'%(l,l))\n",
+    "            terms += 2*gamma[l,l,1]\n",
+    "    print('k: ',k,' terms: ',terms)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 121,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "kp:  0  terms:  C*gamma[0, 0, 0] - L*gamma[1, 0, 0]\n",
+      "kp:  1  terms:  C*gamma[0, 0, 1] + C*gamma[1, 0, 0] - L*gamma[1, 0, 1] - L*gamma[1, 1, 0]\n",
+      "kp:  2  terms:  C*gamma[0, 0, 2] + C*gamma[1, 0, 1] + C*gamma[2, 0, 0] - L*gamma[1, 0, 2] - L*gamma[1, 1, 1] - L*gamma[2, 1, 0]\n",
+      "kp:  3  terms:  C*gamma[1, 0, 2] + C*gamma[2, 0, 1] - L*gamma[1, 1, 2] - L*gamma[2, 1, 1]\n",
+      "kp:  4  terms:  C*gamma[2, 0, 2] - L*gamma[2, 1, 2]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# For the electron-nuclear cusp\n",
+    "for kp in range(0,NN_en + NN_ee+1):\n",
+    "    terms = 0\n",
+    "    if kp <= NN_ee:\n",
+    "        terms = C*gamma[0,0,kp] - L*gamma[1,0,kp]\n",
+    "    # sum of l,n such that l + n == kp and l>=1\n",
+    "    for l in range(1,NN_en+1):\n",
+    "        for n in range(NN_ee+1):\n",
+    "            if l + n == kp:\n",
+    "                terms += C*gamma[l,0,n] - L*gamma[l,1,n]\n",
+    "    print('kp: ',kp,' terms: ',terms)\n",
+    "            \n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/Wavefunctions/gen_three_body.py
+++ b/Wavefunctions/gen_three_body.py
@@ -1,0 +1,176 @@
+from sympy import *
+
+from sympy.printing.cxxcode import CXX11CodePrinter
+from sympy.printing.julia import JuliaCodePrinter
+from sympy.printing.pycode import PythonCodePrinter
+
+
+#
+# Three-body Jastrow code generated in Julia or Python
+# Output is for fixed sizes of the polynomial expansion
+#
+
+def gen_three_body():
+
+    ri = Symbol('r_i')
+    rj = Symbol('r_j')
+    rij = Symbol('r_ij')
+
+    C = Symbol('C')
+    L = Symbol('L')
+    gamma = IndexedBase('gamma')
+    r = IndexedBase('r')
+    l = Symbol('l',integer=True)
+    m = Symbol('m',integer=True)
+    n = Symbol('n',integer=True)
+    N = Symbol('N',integer=True)
+    N_ee = Symbol("N_ee",integer=True)
+    N_en = Symbol("N_en",integer=True)
+
+    f = (ri - L)**C * (rj -L)**C * Sum(Sum(Sum(gamma[l,m,n]*ri**l *rj**m*rij**n,(l,0,N_en)),(n,0,N_en)),(m,0,N_ee))
+
+
+    # Concrete values for the expansion of the above sum
+    NN_ee = 3
+    NN_en = 3
+
+    ff = f.subs(N_en, NN_en).subs(N_ee, NN_ee).doit()
+    #print(ff)
+
+    # Constraints on values of gamma
+
+    # Indices are l,m,n
+    #  l : e1_N
+    #  m : e2_n
+    #  n : e1_e2
+
+    # ---------------------------------------------------
+    # Symmetric under electron interchange (swap l and m)
+    # ---------------------------------------------------
+
+    # Generate substitutions
+
+    sym_subs = {}
+    for i1 in range(NN_en+1):
+        for i2 in range(i1):
+            for i3 in range(NN_ee+1):
+                sym_subs[gamma[i2,i1,i3]] = gamma[i1,i2,i3]
+
+    #print(sym_subs)
+
+    # -----------
+    # No e-e cusp
+    # -----------
+
+    ff_ee = diff(ff, rij).subs(rij,0).subs(rj,ri).subs(sym_subs)
+    #print(ff_ee)
+
+    # remove the (ri-L)**C part.
+    ff_ee2 = ff_ee.args[1]
+
+    #  Collect powers of ri
+    ff_ee3 = collect(expand(ff_ee2), ri)
+    #print(ff_ee3)
+    # For the expression to be zero for arbitrary ri, each coefficient must be zero separately
+
+    pt_ee = poly(ff_ee3, ri)
+    cf_ee = pt_ee.all_coeffs()
+    #print(cf_ee2)
+
+    ee_soln = solve(cf_ee)
+    print('e-e constraints')
+    print(ee_soln)
+    print()
+
+
+    # -----------
+    # No e-n cusp
+    # -----------
+
+    ff_en = diff(ff,ri).subs(ri, 0).subs(rij, rj)
+
+    ff_en2 = simplify(expand(ff_en))
+    #print(ff_en2)
+
+    # remove the (-L)**(C-1) * (rj - L)**C part
+    ff_en3 = ff_en2.args[2]
+    #print(ff_en3)
+
+    ff_en4 = ff_en3.subs(sym_subs).subs(ee_soln)
+
+    # For the expression to be zero for arbitrary ri, each coefficient must be zero separately
+
+    pt_en = poly(ff_en4, rj)
+    cf_en = pt_en.all_coeffs()
+    print('e-n constraint equations')
+    print(cf_en)
+
+    #en_soln = solve(cf_en)
+
+    en_gamma = {a for a in ff_en4.free_symbols if type(a) is Indexed}
+    print('en_gamma = ',en_gamma)
+    en_soln = linsolve(cf_en, en_gamma)
+    print('e-n solution')
+    print(en_soln)
+    print('-------')
+
+    en_soln_idx = 0
+
+    # Sometimes {C:0, L:0} is the first solution.  Don't want that one.
+    #if len(en_soln) > 1:
+    #    if C in en_soln[0].keys():
+    #        en_soln_idx = 1
+    #  Attempts to add constraints to C to avoid that solution never worked
+    #  as expected
+
+    #en_soln2 = en_soln[en_soln_idx]
+    en_soln2 = None
+    for tmp_en in en_soln:
+        en_soln2 = {g:v for g,v in zip(en_gamma, tmp_en)}
+
+    print('e-n constraints')
+    print(en_soln2)
+    print('-------')
+
+    fout = ff.subs(sym_subs).subs(ee_soln).subs(en_soln2)
+
+    print('Final value')
+    print(fout)
+    print()
+    free_gamma = {a for a in fout.free_symbols if type(a) is Indexed}
+    print('Number of free gamma:', len(free_gamma))
+    print('Free gamma: ',free_gamma)
+
+    # Replace indexing with variable names
+    #gamma_subs = {}
+    #for gamma_indexed in free_gamma:
+    #    suffix = ''.join([str(j) for j in gamma_indexed.args[1:]])
+    #    gamma_name = 'g' + suffix
+    #    gamma_subs[gamma_indexed] = gamma_name
+    #fout = fout.subs(gamma[1,1,0], Symbol('g110'))
+
+    # Replace 3-dim index with 1-dim contiguous
+    gamma_subs = {}
+    gbase = IndexedBase('g')
+    for idx,gamma_indexed in enumerate(free_gamma):
+        gamma_subs[gamma_indexed] = gbase[idx+1]
+
+
+    fout = fout.subs(gamma_subs)
+
+
+    if True:
+        JC = JuliaCodePrinter(settings={'inline':False})
+        s = JC.doprint(fout)
+        print('Julia code')
+        print(s)
+
+    if False:
+        PC = PythonCodePrinter(settings={'inline':False})
+        s = PC.doprint(fout)
+        print('Python code')
+        print(s)
+
+
+if __name__ == '__main__':
+   gen_three_body()


### PR DESCRIPTION
This is the polynomial three-body Jastrow used in QMCPACK.
The Jupyter notebook has it in symbolic form and can derive the constraints on the coefficients.
The code generation script can output Python or Julia for fixed sizes of the polynomial expansion.